### PR TITLE
[EXE-1565] Set up aiq deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1290,25 +1290,34 @@ option("key", "value") > spark.conf > hadoop configuration
 # Prereqs
 The user/password for Artifactory should come from ~/.m2/settings.xml, which was created by the AIQ laptop script.
 
+Download / create a JSON file containing real GCP credentials
+```
+export GOOGLE_APPLICATION_CREDENTIALS=<path to json file>
+```
+
 # Version
 Bump `revision` in `spark-bigquery-parent/pom.xml` to the next `-aiq#` version
 
 # Build
 This places artifacts in `~/.m2/repository/`
 ```
-./mvnw clean install -DskipTests
+./mvnw clean install
 ```
 
 # Tests
-Full tests dont work, they require configuring GCP settings, so just make sure projects
-we care about are passing. Or if you are making a change, confirm the same tests fail with
-and without the change.
+Run all tests except acceptance test and integration tests
 ```
 ./mvnw test -fn
+```
+
+Acceptance Tests and Integration Tests need additional GCP settings
+```
+./mvnw integration-test -P acceptance
+./mvnw integration-test -P integration
 ```
 
 # Deploy
 To deploy to AIQ artifactory https://actioniq.jfrog.io/artifactory/aiq-sbt-local
 ```
-./mvnw deploy -DskipTests
+./mvnw deploy
 ```

--- a/README.md
+++ b/README.md
@@ -1284,3 +1284,31 @@ You can set the following in the hadoop configuration as well.
 If the same parameter is set at multiple places the order of priority is as follows:
 
 option("key", "value") > spark.conf > hadoop configuration
+
+## AIQ DEV
+
+# Prereqs
+The user/password for Artifactory should come from ~/.m2/settings.xml, which was created by the AIQ laptop script.
+
+# Version
+Bump `revision` in `spark-bigquery-parent/pom.xml` to the next `-aiq#` version
+
+# Build
+This places artifacts in `~/.m2/repository/`
+```
+./mvnw clean install -DskipTests
+```
+
+# Tests
+Full tests dont work, they require configuring GCP settings, so just make sure projects
+we care about are passing. Or if you are making a change, confirm the same tests fail with
+and without the change.
+```
+./mvnw test -fn
+```
+
+# Deploy
+To deploy to AIQ artifactory https://actioniq.jfrog.io/artifactory/aiq-sbt-local
+```
+./mvnw deploy -DskipTests
+```

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -690,7 +690,7 @@ public class BigQueryClient {
     }
 
     TableInfo createTableFromQuery() {
-      log.debug("destinationTable is %s", destinationTable);
+      log.debug("destinationTable is {}", destinationTable.toString());
       JobInfo jobInfo =
           JobInfo.of(
               jobConfigurationFactory
@@ -698,9 +698,9 @@ public class BigQueryClient {
                   .setDestinationTable(destinationTable)
                   .build());
 
-      log.debug("running query %s", jobInfo);
+      log.debug("running query {}", jobInfo.toString());
       Job job = waitForJob(bigQueryClient.create(jobInfo));
-      log.debug("job has finished. %s", job);
+      log.debug("job has finished {}", job.toString());
       if (job.getStatus().getError() != null) {
         throw BigQueryUtil.convertToBigQueryException(job.getStatus().getError());
       }
@@ -709,7 +709,12 @@ public class BigQueryClient {
       long expirationTime =
           createdTable.getCreationTime() + TimeUnit.MINUTES.toMillis(expirationTimeInMinutes);
       Table updatedTable =
-          bigQueryClient.update(createdTable.toBuilder().setExpirationTime(expirationTime).build());
+          bigQueryClient.update(
+              createdTable
+                  .toBuilder()
+                  .setExpirationTime(expirationTime)
+                  .setLabels(additionalQueryJobLabels)
+                  .build());
       return updatedTable;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
     <profile>
       <id>dsv2_3.3</id>
       <activation>
-        <activeByDefault>false</activeByDefault>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <modules>
         <module>spark-bigquery-dsv2/spark-bigquery-dsv2-common</module>

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
     <profile>
       <id>dsv2_3.3</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
       </activation>
       <modules>
         <module>spark-bigquery-dsv2/spark-bigquery-dsv2-common</module>
@@ -228,6 +228,40 @@
         <module>spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12</module>
         <module>spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.13</module>
         <module>spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12</module>
+        <module>spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.13</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>dsv2_3.3_2.12</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>spark-bigquery-dsv2/spark-bigquery-dsv2-common</module>
+        <module>spark-bigquery-dsv2/spark-bigquery-dsv2-parent</module>
+        <module>spark-bigquery-dsv2/spark-3.1-bigquery-lib</module>
+        <module>spark-bigquery-dsv2/spark-3.2-bigquery-lib</module>
+        <module>spark-bigquery-dsv2/spark-3.3-bigquery-lib</module>
+        <module>spark-bigquery-dsv2/spark-3.3-bigquery_2.12</module>
+        <module>spark-bigquery-pushdown/spark-bigquery-pushdown-parent</module>
+        <module>spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12</module>
+        <module>spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>dsv2_3.3_2.13</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <modules>
+        <module>spark-bigquery-dsv2/spark-bigquery-dsv2-common</module>
+        <module>spark-bigquery-dsv2/spark-bigquery-dsv2-parent</module>
+        <module>spark-bigquery-dsv2/spark-3.1-bigquery-lib</module>
+        <module>spark-bigquery-dsv2/spark-3.2-bigquery-lib</module>
+        <module>spark-bigquery-dsv2/spark-3.3-bigquery-lib</module>
+        <module>spark-bigquery-dsv2/spark-3.3-bigquery_2.13</module>
+        <module>spark-bigquery-pushdown/spark-bigquery-pushdown-parent</module>
+        <module>spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.13</module>
         <module>spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.13</module>
       </modules>
     </profile>

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -960,7 +960,7 @@ public class SparkBigQueryConfig
     }
 
     static boolean isSpark24OrAbove(String sparkVersion) {
-      return sparkVersion.compareTo("2.4") > 0;
+      return sparkVersion.compareTo("2.4") > 0 || sparkVersion.compareTo("2-4") > 0;
     }
 
     // could not load the spark-avro data source

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -960,7 +960,7 @@ public class SparkBigQueryConfig
     }
 
     static boolean isSpark24OrAbove(String sparkVersion) {
-      return sparkVersion.compareTo("2.4") > 0 || sparkVersion.compareTo("2-4") > 0;
+      return sparkVersion.replace("-", ".").compareTo("2.4") > 0;
     }
 
     // could not load the spark-avro data source

--- a/spark-bigquery-dsv2/spark-3.3-bigquery/pom.xml
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery/pom.xml
@@ -15,6 +15,7 @@
   <properties>
     <spark.version>3.3.0</spark.version>
     <shade.skip>false</shade.skip>
+    <deploy.skip>false</deploy.skip>
   </properties>
   <licenses>
     <license>

--- a/spark-bigquery-dsv2/spark-3.3-bigquery/pom.xml
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery/pom.xml
@@ -15,7 +15,6 @@
   <properties>
     <spark.version>3.3.0</spark.version>
     <shade.skip>false</shade.skip>
-    <deploy.skip>false</deploy.skip>
   </properties>
   <licenses>
     <license>

--- a/spark-bigquery-dsv2/spark-3.3-bigquery/pom.xml
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery/pom.xml
@@ -13,7 +13,7 @@
   <version>${revision}</version>
   <name>BigQuery DataSource v2 for Spark 3.3</name>
   <properties>
-    <spark.version>3.3.0</spark.version>
+    <spark.version>3.3.2</spark.version>
     <shade.skip>false</shade.skip>
   </properties>
   <licenses>

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/pom.xml
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/pom.xml
@@ -9,12 +9,13 @@
     <relativePath>../spark-bigquery-dsv2-parent</relativePath>
   </parent>
 
-  <artifactId>spark-3.3-bigquery-lib</artifactId>
+  <artifactId>spark-3.3-bigquery_2.12</artifactId>
   <version>${revision}</version>
-  <name>Connector code for BigQuery DataSource v2 for Spark 3.3</name>
+  <name>BigQuery DataSource v2 for Spark 3.3, Scala 2.12</name>
   <properties>
     <spark.version>3.3.2</spark.version>
-    <shade.skip>true</shade.skip>
+    <shade.skip>false</shade.skip>
+    <scala.binary.version>2.12</scala.binary.version>
   </properties>
   <licenses>
     <license>
@@ -26,7 +27,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>spark-3.2-bigquery-lib</artifactId>
+      <artifactId>spark-3.3-bigquery-lib</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -34,6 +35,12 @@
       <artifactId>spark-avro_2.12</artifactId>
       <version>${spark.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>spark-3.3-bigquery-pushdown_2.12
+      </artifactId>
+      <version>${project.parent.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/build/resources/spark-bigquery-connector.properties
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/build/resources/spark-bigquery-connector.properties
@@ -1,0 +1,1 @@
+connector.version=${project.version}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,0 +1,1 @@
+com.google.cloud.spark.bigquery.v2.Spark33BigQueryTableProvider

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33BigNumericDataprocServerlessAcceptanceTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33BigNumericDataprocServerlessAcceptanceTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.acceptance;
+
+public class Spark33BigNumericDataprocServerlessAcceptanceTest
+    extends BigNumericDataprocServerlessAcceptanceTestBase {
+
+  public Spark33BigNumericDataprocServerlessAcceptanceTest() {
+    super("spark-3.3-bigquery_2.12", "2.0");
+  }
+
+  // tests from superclass
+
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33DataprocImage21AcceptanceTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33DataprocImage21AcceptanceTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.acceptance;
+
+import java.util.Collections;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+public class Spark33DataprocImage21AcceptanceTest extends DataprocAcceptanceTestBase {
+
+  private static AcceptanceTestContext context;
+
+  public Spark33DataprocImage21AcceptanceTest() {
+    super(context, false);
+  }
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    context =
+        DataprocAcceptanceTestBase.setup(
+            "2.1-debian11", "spark-3.3-bigquery_2.12", Collections.emptyList());
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    DataprocAcceptanceTestBase.tearDown(context);
+  }
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33DataprocImage21DisableConscryptAcceptanceTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33DataprocImage21DisableConscryptAcceptanceTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.acceptance;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+public class Spark33DataprocImage21DisableConscryptAcceptanceTest
+    extends DataprocAcceptanceTestBase {
+
+  private static AcceptanceTestContext context;
+
+  public Spark33DataprocImage21DisableConscryptAcceptanceTest() {
+    super(context, false);
+  }
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    context =
+        DataprocAcceptanceTestBase.setup(
+            "2.1-debian11", "spark-3.3-bigquery_2.12", DISABLE_CONSCRYPT_LIST);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    DataprocAcceptanceTestBase.tearDown(context);
+  }
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33ReadSheakspeareDataprocServerlessAcceptanceTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33ReadSheakspeareDataprocServerlessAcceptanceTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.acceptance;
+
+public class Spark33ReadSheakspeareDataprocServerlessAcceptanceTest
+    extends ReadSheakspeareDataprocServerlessAcceptanceTestBase {
+
+  public Spark33ReadSheakspeareDataprocServerlessAcceptanceTest() {
+    super("spark-3.3-bigquery_2.12", "2.0");
+  }
+
+  // tests from superclass
+
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33WriteStreamDataprocServerlessAcceptanceTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33WriteStreamDataprocServerlessAcceptanceTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.acceptance;
+
+import org.junit.Ignore;
+
+@Ignore // spark-3.3-bigquery does not support streaming yet
+public class Spark33WriteStreamDataprocServerlessAcceptanceTest
+    extends WriteStreamDataprocServerlessAcceptanceTestBase {
+
+  public Spark33WriteStreamDataprocServerlessAcceptanceTest() {
+    super("spark-3.3-bigquery_2.12", "2.0");
+  }
+
+  // tests from superclass
+
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33DirectWriteIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33DirectWriteIntegrationTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
+
+public class Spark33DirectWriteIntegrationTest extends WriteIntegrationTestBase {
+
+  public Spark33DirectWriteIntegrationTest() {
+    super(SparkBigQueryConfig.WriteMethod.DIRECT);
+  }
+
+  // tests from superclass
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33IndirectWriteIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33IndirectWriteIntegrationTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
+import org.junit.Before;
+
+public class Spark33IndirectWriteIntegrationTest extends WriteIntegrationTestBase {
+
+  public Spark33IndirectWriteIntegrationTest() {
+    super(SparkBigQueryConfig.WriteMethod.INDIRECT);
+  }
+
+  @Before
+  public void setParquetLoadBehaviour() {
+    // TODO: make this the default value
+    spark.conf().set("enableListInference", "true");
+  }
+
+  // tests from superclass
+
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33QueryPushdownIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33QueryPushdownIntegrationTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+import com.google.cloud.spark.bigquery.BigQueryConnectorUtils;
+import org.junit.Before;
+
+public class Spark33QueryPushdownIntegrationTest extends QueryPushdownIntegrationTestBase {
+
+  @Before
+  public void before() {
+    BigQueryConnectorUtils.enablePushdownSession(spark);
+  }
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33ReadByFormatIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33ReadByFormatIntegrationTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+public class Spark33ReadByFormatIntegrationTest extends ReadByFormatIntegrationTestBase {
+
+  public Spark33ReadByFormatIntegrationTest() {
+    super("ARROW", /* userProvidedSchemaAllowed */ false);
+  }
+
+  // tests are from the super-class
+
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33ReadFromQueryIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33ReadFromQueryIntegrationTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+public class Spark33ReadFromQueryIntegrationTest extends ReadFromQueryIntegrationTestBase {
+
+  // tests are from the super-class
+
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33ReadIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33ReadIntegrationTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+public class Spark33ReadIntegrationTest extends ReadIntegrationTestBase {
+  public Spark33ReadIntegrationTest() {
+    super(/* userProvidedSchemaAllowed */ false);
+  }
+
+  // tests are from the super-class
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/pom.xml
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/pom.xml
@@ -9,12 +9,13 @@
     <relativePath>../spark-bigquery-dsv2-parent</relativePath>
   </parent>
 
-  <artifactId>spark-3.3-bigquery-lib</artifactId>
+  <artifactId>spark-3.3-bigquery_2.13</artifactId>
   <version>${revision}</version>
-  <name>Connector code for BigQuery DataSource v2 for Spark 3.3</name>
+  <name>BigQuery DataSource v2 for Spark 3.3, Scala 2.13</name>
   <properties>
     <spark.version>3.3.2</spark.version>
-    <shade.skip>true</shade.skip>
+    <shade.skip>false</shade.skip>
+    <scala.binary.version>2.13</scala.binary.version>
   </properties>
   <licenses>
     <license>
@@ -26,14 +27,20 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>spark-3.2-bigquery-lib</artifactId>
+      <artifactId>spark-3.3-bigquery-lib</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-avro_2.12</artifactId>
+      <artifactId>spark-avro_2.13</artifactId>
       <version>${spark.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>spark-3.3-bigquery-pushdown_2.13
+      </artifactId>
+      <version>${project.parent.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/build/resources/spark-bigquery-connector.properties
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/build/resources/spark-bigquery-connector.properties
@@ -1,0 +1,1 @@
+connector.version=${project.version}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,0 +1,1 @@
+com.google.cloud.spark.bigquery.v2.Spark33BigQueryTableProvider

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33BigNumericDataprocServerlessAcceptanceTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33BigNumericDataprocServerlessAcceptanceTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.acceptance;
+
+public class Spark33BigNumericDataprocServerlessAcceptanceTest
+    extends BigNumericDataprocServerlessAcceptanceTestBase {
+
+  public Spark33BigNumericDataprocServerlessAcceptanceTest() {
+    super("spark-3.3-bigquery_2.13", "2.0");
+  }
+
+  // tests from superclass
+
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33DataprocImage21AcceptanceTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33DataprocImage21AcceptanceTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.acceptance;
+
+import java.util.Collections;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+public class Spark33DataprocImage21AcceptanceTest extends DataprocAcceptanceTestBase {
+
+  private static AcceptanceTestContext context;
+
+  public Spark33DataprocImage21AcceptanceTest() {
+    super(context, false);
+  }
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    context =
+        DataprocAcceptanceTestBase.setup(
+            "2.1-debian11", "spark-3.3-bigquery_2.13", Collections.emptyList());
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    DataprocAcceptanceTestBase.tearDown(context);
+  }
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33DataprocImage21DisableConscryptAcceptanceTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33DataprocImage21DisableConscryptAcceptanceTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.acceptance;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+public class Spark33DataprocImage21DisableConscryptAcceptanceTest
+    extends DataprocAcceptanceTestBase {
+
+  private static AcceptanceTestContext context;
+
+  public Spark33DataprocImage21DisableConscryptAcceptanceTest() {
+    super(context, false);
+  }
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    context =
+        DataprocAcceptanceTestBase.setup(
+            "2.1-debian11", "spark-3.3-bigquery_2.13", DISABLE_CONSCRYPT_LIST);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    DataprocAcceptanceTestBase.tearDown(context);
+  }
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33ReadSheakspeareDataprocServerlessAcceptanceTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33ReadSheakspeareDataprocServerlessAcceptanceTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.acceptance;
+
+public class Spark33ReadSheakspeareDataprocServerlessAcceptanceTest
+    extends ReadSheakspeareDataprocServerlessAcceptanceTestBase {
+
+  public Spark33ReadSheakspeareDataprocServerlessAcceptanceTest() {
+    super("spark-3.3-bigquery_2.13", "2.0");
+  }
+
+  // tests from superclass
+
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33WriteStreamDataprocServerlessAcceptanceTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/acceptance/Spark33WriteStreamDataprocServerlessAcceptanceTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.acceptance;
+
+import org.junit.Ignore;
+
+@Ignore // spark-3.3-bigquery does not support streaming yet
+public class Spark33WriteStreamDataprocServerlessAcceptanceTest
+    extends WriteStreamDataprocServerlessAcceptanceTestBase {
+
+  public Spark33WriteStreamDataprocServerlessAcceptanceTest() {
+    super("spark-3.3-bigquery_2.13", "2.0");
+  }
+
+  // tests from superclass
+
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33DirectWriteIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33DirectWriteIntegrationTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
+
+public class Spark33DirectWriteIntegrationTest extends WriteIntegrationTestBase {
+
+  public Spark33DirectWriteIntegrationTest() {
+    super(SparkBigQueryConfig.WriteMethod.DIRECT);
+  }
+
+  // tests from superclass
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33IndirectWriteIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33IndirectWriteIntegrationTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
+import org.junit.Before;
+
+public class Spark33IndirectWriteIntegrationTest extends WriteIntegrationTestBase {
+
+  public Spark33IndirectWriteIntegrationTest() {
+    super(SparkBigQueryConfig.WriteMethod.INDIRECT);
+  }
+
+  @Before
+  public void setParquetLoadBehaviour() {
+    // TODO: make this the default value
+    spark.conf().set("enableListInference", "true");
+  }
+
+  // tests from superclass
+
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33QueryPushdownIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33QueryPushdownIntegrationTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+import com.google.cloud.spark.bigquery.BigQueryConnectorUtils;
+import org.junit.Before;
+
+public class Spark33QueryPushdownIntegrationTest extends QueryPushdownIntegrationTestBase {
+
+  @Before
+  public void before() {
+    BigQueryConnectorUtils.enablePushdownSession(spark);
+  }
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33ReadByFormatIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33ReadByFormatIntegrationTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+public class Spark33ReadByFormatIntegrationTest extends ReadByFormatIntegrationTestBase {
+
+  public Spark33ReadByFormatIntegrationTest() {
+    super("ARROW", /* userProvidedSchemaAllowed */ false);
+  }
+
+  // tests are from the super-class
+
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33ReadFromQueryIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33ReadFromQueryIntegrationTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+public class Spark33ReadFromQueryIntegrationTest extends ReadFromQueryIntegrationTestBase {
+
+  // tests are from the super-class
+
+}

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33ReadIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.13/src/test/java/com/google/cloud/spark/bigquery/integration/Spark33ReadIntegrationTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+public class Spark33ReadIntegrationTest extends ReadIntegrationTestBase {
+  public Spark33ReadIntegrationTest() {
+    super(/* userProvidedSchemaAllowed */ false);
+  }
+
+  // tests are from the super-class
+}

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
@@ -14,6 +14,7 @@
   <packaging>pom</packaging>
   <properties>
     <spark.version>2.4.0</spark.version>
+    <scala.binary.version>2.12</scala.binary.version>
   </properties>
   <licenses>
     <license>
@@ -30,7 +31,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-mllib_2.12</artifactId>
+      <artifactId>spark-mllib_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
       <exclusions>
@@ -42,7 +43,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_2.12</artifactId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
       <exclusions>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -49,7 +49,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq2</revision>
+        <revision>0.30.0-aiq3</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>
@@ -69,6 +69,9 @@
         <deploy.skip>false</deploy.skip>
         <nexus.remote.skip>false</nexus.remote.skip>
         <shade.skip>true</shade.skip>
+        <argLine>
+            --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+        </argLine>
         <!-- checkstyle
         <checkstyle.header.file>${reactor.project.basedir}/java.header</checkstyle.header.file>
         -->

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -49,7 +49,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq0</revision>
+        <revision>0.30.0-aiq1</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -49,7 +49,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq1</revision>
+        <revision>0.30.0-aiq2</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -66,7 +66,7 @@
         <paranamer.version>2.8</paranamer.version>
         <protobuf.version>3.22.2</protobuf.version>
         <zstd.version>1.4.9-1</zstd.version>
-        <deploy.skip>false</deploy.skip>
+        <deploy.skip>true</deploy.skip>
         <nexus.remote.skip>false</nexus.remote.skip>
         <shade.skip>true</shade.skip>
         <!-- checkstyle

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -66,7 +66,7 @@
         <paranamer.version>2.8</paranamer.version>
         <protobuf.version>3.22.2</protobuf.version>
         <zstd.version>1.4.9-1</zstd.version>
-        <deploy.skip>true</deploy.skip>
+        <deploy.skip>false</deploy.skip>
         <nexus.remote.skip>false</nexus.remote.skip>
         <shade.skip>true</shade.skip>
         <!-- checkstyle

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -38,18 +38,18 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>aiq-snapshots-artifactory</id>
+            <url>https://actioniq.jfrog.io/artifactory/aiq-sbt-local</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>aiq-releases-artifactory</id>
+            <url>https://actioniq.jfrog.io/artifactory/aiq-sbt-local</url>
         </repository>
     </distributionManagement>
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.0.1-SNAPSHOT</revision>
+        <revision>0.30.0-aiq0</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>
@@ -66,7 +66,7 @@
         <paranamer.version>2.8</paranamer.version>
         <protobuf.version>3.22.2</protobuf.version>
         <zstd.version>1.4.9-1</zstd.version>
-        <deploy.skip>true</deploy.skip>
+        <deploy.skip>false</deploy.skip>
         <nexus.remote.skip>false</nexus.remote.skip>
         <shade.skip>true</shade.skip>
         <!-- checkstyle
@@ -367,8 +367,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQueryStrategy.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQueryStrategy.scala
@@ -44,6 +44,7 @@ abstract class BigQueryStrategy(expressionConverter: SparkExpressionConverter, e
     }
 
     try {
+      logDebug(s"Trying Query pushdown for plan ${plan}")
       generateSparkPlanFromLogicalPlan(plan)
     } catch {
       // We catch all exceptions here (including BigQueryPushdownUnsupportedException)

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryPushdown.scala
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryPushdown.scala
@@ -19,7 +19,7 @@ package com.google.cloud.spark.bigquery.pushdowns
 class Spark24BigQueryPushdown extends BaseSparkBigQueryPushdown {
 
   override def supportsSparkVersion(sparkVersion: String): Boolean = {
-    sparkVersion.startsWith("2.4")
+    sparkVersion.startsWith("2.4") || sparkVersion.startsWith("2-4")
   }
 
   override def createSparkExpressionConverter(expressionFactory: SparkExpressionFactory, sparkPlanFactory: SparkPlanFactory): SparkExpressionConverter = {

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryPushdown.scala
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryPushdown.scala
@@ -19,7 +19,7 @@ package com.google.cloud.spark.bigquery.pushdowns
 class Spark24BigQueryPushdown extends BaseSparkBigQueryPushdown {
 
   override def supportsSparkVersion(sparkVersion: String): Boolean = {
-    sparkVersion.startsWith("2.4")
+    sparkVersion.startsWith("2.4") || sparkVersion.startsWith("2-4")
   }
 
   override def createSparkExpressionConverter(expressionFactory: SparkExpressionFactory, sparkPlanFactory: SparkPlanFactory): SparkExpressionConverter = {

--- a/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12/pom.xml
@@ -14,6 +14,7 @@
 
   <properties>
     <scala.binary.version>2.12</scala.binary.version>
+    <scala.patch.version>15</scala.patch.version>
     <spark.version>3.3.2</spark.version>
   </properties>
 

--- a/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <scala.binary.version>2.12</scala.binary.version>
-    <spark.version>3.3.0</spark.version>
+    <spark.version>3.3.2</spark.version>
   </properties>
 
   <dependencies>

--- a/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark33BigQueryPushdown.scala
+++ b/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark33BigQueryPushdown.scala
@@ -19,7 +19,7 @@ package com.google.cloud.spark.bigquery.pushdowns
 class Spark33BigQueryPushdown extends BaseSparkBigQueryPushdown {
 
   override def supportsSparkVersion(sparkVersion: String): Boolean = {
-    sparkVersion.startsWith("3.3")
+    sparkVersion.startsWith("3.3") || sparkVersion.startsWith("3-3")
   }
 
   override def createSparkExpressionConverter(expressionFactory: SparkExpressionFactory, sparkPlanFactory: SparkPlanFactory): SparkExpressionConverter = {

--- a/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.13/pom.xml
+++ b/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.13/pom.xml
@@ -14,7 +14,8 @@
 
   <properties>
     <scala.binary.version>2.13</scala.binary.version>
-    <spark.version>3.3.0</spark.version>
+    <scala.patch.version>10</scala.patch.version>
+    <spark.version>3.3.2</spark.version>
   </properties>
 
   <dependencies>

--- a/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.13/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark33BigQueryPushdown.scala
+++ b/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.13/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark33BigQueryPushdown.scala
@@ -19,7 +19,7 @@ package com.google.cloud.spark.bigquery.pushdowns
 class Spark33BigQueryPushdown extends BaseSparkBigQueryPushdown {
 
   override def supportsSparkVersion(sparkVersion: String): Boolean = {
-    sparkVersion.startsWith("3.3")
+    sparkVersion.startsWith("3.3") || sparkVersion.startsWith("3-3")
   }
 
   override def createSparkExpressionConverter(expressionFactory: SparkExpressionFactory, sparkPlanFactory: SparkPlanFactory): SparkExpressionConverter = {

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12/pom.xml
@@ -14,6 +14,7 @@
 
   <properties>
     <scala.binary.version>2.12</scala.binary.version>
+    <scala.patch.version>15</scala.patch.version>
     <spark.version>3.3.2</spark.version>
   </properties>
 

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12/pom.xml
@@ -14,12 +14,12 @@
 
   <properties>
     <scala.binary.version>2.12</scala.binary.version>
-    <spark.version>3.1.0</spark.version>
+    <spark.version>3.3.2</spark.version>
   </properties>
 
   <build>
     <plugins>
-      <!-- make sure we don't have any _2.10 or _2.11 dependencies when building
+      <!-- make sure we don't have any _2.10 or _2.11 or _2.13 dependencies when building
       for Scala 2.12 -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -37,6 +37,7 @@
                   <excludes combine.children="append">
                     <exclude>*:*_2.10</exclude>
                     <exclude>*:*_2.11</exclude>
+                    <exclude>*:*_2.13</exclude>
                   </excludes>
                 </bannedDependencies>
               </rules>

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.13/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.13/pom.xml
@@ -14,7 +14,8 @@
 
   <properties>
     <scala.binary.version>2.13</scala.binary.version>
-    <spark.version>3.2.0</spark.version>
+    <scala.patch.version>10</scala.patch.version>
+    <spark.version>3.3.2</spark.version>
   </properties>
 
   <build>

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-parent/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-parent/pom.xml
@@ -107,9 +107,6 @@
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <scalaVersion>${scala.binary.version}</scalaVersion>
-        </configuration>
       </plugin>
       <!-- enable scalatest -->
       <plugin>

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-parent/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-parent/pom.xml
@@ -16,6 +16,7 @@
   <packaging>pom</packaging>
   <properties>
     <scala.binary.version>2.11</scala.binary.version>
+    <scala.patch.version>0</scala.patch.version>
     <spark.version>2.4.0</spark.version>
   </properties>
   <licenses>
@@ -99,6 +100,9 @@
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
         <version>4.4.0</version>
+        <configuration>
+          <scalaVersion>${scala.binary.version}.${scala.patch.version}</scalaVersion>
+        </configuration>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
Set up deploying to Artifactory; add aiq README

Adding scala binary version to `spark-3.3-bigquery`:
* Create two new projects from the existing spark-3.3-bigquery project (mostly copy-paste): `spark-3.3-bigquery_2.12` and `spark-3.3-bigquery_2.12` by including dependencies that have corresponding scala version
* Create two new profiles `dsv2_3.3_2.12` (active) and `dsv2_3.3_2.13`, each including dependencies of corresponding scala version (as oppose to containing both 2.12 and 2.13)

Also bringing in tagging and debugging in [this PR](https://github.com/ActionIQ/spark-bigquery-connector/pull/5) (didn't add queryJobLabel to query job because turned out it has already been attached)

resolve an issue with scala - java 17 incompatibility issue by specifying full scala version (binary.patch) for `scala-maven-plugin`


`./mvnw deploy`