### PR TITLE
[EXE-1565] Expose sql statement to Spark33BigQueryPushdownPlan

### DIFF
--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -49,7 +49,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq3</revision>
+        <revision>0.30.0-aiq4</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>

--- a/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark33BigQueryPushdownPlan.scala
+++ b/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark33BigQueryPushdownPlan.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.SparkPlan
 
 /** BigQueryPlan, with RDD defined by custom query. */
-case class Spark33BigQueryPushdownPlan(output: Seq[Attribute], rdd: RDD[InternalRow])
+case class Spark33BigQueryPushdownPlan(output: Seq[Attribute], rdd: RDD[InternalRow], sqlString: String)
   extends SparkPlan {
 
   override def children: Seq[SparkPlan] = Nil

--- a/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark33PlanFactory.scala
+++ b/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark33PlanFactory.scala
@@ -23,6 +23,13 @@ class Spark33PlanFactory extends SparkPlanFactory {
    * Generate SparkPlan from the output and RDD of the translated query
    */
   override def createBigQueryPlan(queryRoot: BigQuerySQLQuery, bigQueryRDDFactory: BigQueryRDDFactory): Option[SparkPlan] = {
-    Some(Spark33BigQueryPushdownPlan(queryRoot.output, bigQueryRDDFactory.buildScanFromSQL(queryRoot.getStatement().toString)))
+    val sqlStr = queryRoot.getStatement().toString
+    Some(
+      Spark33BigQueryPushdownPlan(
+        queryRoot.output,
+        bigQueryRDDFactory.buildScanFromSQL(sqlStr),
+        sqlStr
+      )
+    )
   }
 }

--- a/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.13/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark33BigQueryPushdownPlan.scala
+++ b/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.13/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark33BigQueryPushdownPlan.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.SparkPlan
 
 /** BigQueryPlan, with RDD defined by custom query. */
-case class Spark33BigQueryPushdownPlan(output: Seq[Attribute], rdd: RDD[InternalRow])
+case class Spark33BigQueryPushdownPlan(output: Seq[Attribute], rdd: RDD[InternalRow], sqlString: String)
   extends SparkPlan {
 
   override def children: Seq[SparkPlan] = Nil

--- a/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.13/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark33PlanFactory.scala
+++ b/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.13/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark33PlanFactory.scala
@@ -22,7 +22,16 @@ class Spark33PlanFactory extends SparkPlanFactory {
   /**
    * Generate SparkPlan from the output and RDD of the translated query
    */
-  override def createBigQueryPlan(queryRoot: BigQuerySQLQuery, bigQueryRDDFactory: BigQueryRDDFactory): Option[SparkPlan] = {
-    Some(Spark33BigQueryPushdownPlan(queryRoot.output, bigQueryRDDFactory.buildScanFromSQL(queryRoot.getStatement().toString)))
+  override def createBigQueryPlan(
+    queryRoot: BigQuerySQLQuery, bigQueryRDDFactory: BigQueryRDDFactory
+  ): Option[SparkPlan] = {
+    val sqlStr = queryRoot.getStatement().toString
+    Some(
+      Spark33BigQueryPushdownPlan(
+        queryRoot.output,
+        bigQueryRDDFactory.buildScanFromSQL(sqlStr),
+        sqlStr
+      )
+    )
   }
 }


### PR DESCRIPTION
Adding the sql statement that will run in BigQuery to the Spark33BigQueryPushdownPlan.
Note I only did this for scala 2.12 and 2.13

```
./mvnw test
./mvnw test -P dsv2_3.3
```

Deployed a new version and tested with flame in spark-shell