### PR TITLE
[EXE-1966] Use aiq flame artifacts

### DIFF
--- a/spark-bigquery-connector-common/pom.xml
+++ b/spark-bigquery-connector-common/pom.xml
@@ -40,8 +40,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.12</artifactId>
-            <version>2-4-7-aiq66</version>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -52,8 +52,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-mllib_2.12</artifactId>
-            <version>2-4-7-aiq66</version>
+            <artifactId>spark-mllib_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/spark-bigquery-connector-common/pom.xml
+++ b/spark-bigquery-connector-common/pom.xml
@@ -40,8 +40,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.13</artifactId>
-            <version>3.3.0</version>
+            <artifactId>spark-sql_2.12</artifactId>
+            <version>2-4-7-aiq66</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -52,8 +52,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-mllib_2.13</artifactId>
-            <version>3.3.0</version>
+            <artifactId>spark-mllib_2.12</artifactId>
+            <version>2-4-7-aiq66</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/spark-bigquery-connector-common/src/main/java/org/apache/spark/sql/Scala213SparkSqlUtils.java
+++ b/spark-bigquery-connector-common/src/main/java/org/apache/spark/sql/Scala213SparkSqlUtils.java
@@ -73,6 +73,8 @@ public class Scala213SparkSqlUtils extends SparkSqlUtils {
                         NamedExpression.newExprId(),
                         new ListBuffer<String>().toSeq()))
             .collect(Collectors.toList());
-    return JavaConverters.asScalaBuffer(result).toSeq();
+    return (scala.collection.immutable.Seq<
+            org.apache.spark.sql.catalyst.expressions.AttributeReference>)
+        scala.collection.JavaConverters.asScalaBuffer(result).toSeq();
   }
 }

--- a/spark-bigquery-connector-common/src/main/java/org/apache/spark/sql/SparkSqlUtils.java
+++ b/spark-bigquery-connector-common/src/main/java/org/apache/spark/sql/SparkSqlUtils.java
@@ -36,7 +36,7 @@ public abstract class SparkSqlUtils {
                   () ->
                       new IllegalArgumentException(
                           String.format(
-                              "Could not load instance of '%', please check the META-INF/services directory in the connector's jar",
+                              "Could not load instance of '%s', please check the META-INF/services directory in the connector's jar",
                               SparkSqlUtils.class.getCanonicalName())));
     }
     return instance;

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -48,7 +48,7 @@ import org.junit.Test;
 public class SparkBigQueryConfigTest {
 
   public static final int DEFAULT_PARALLELISM = 10;
-  public static final String SPARK_VERSION = "2.4.0";
+  public static final String SPARK_VERSION = "2-4-7-aiq66";
   private static ImmutableMap<String, String> build;
   ImmutableMap<String, String> defaultOptions = ImmutableMap.of("table", "dataset.table");
   // "project", "test_project"); // to remove the need for default project

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -479,7 +479,7 @@ public class SparkBigQueryConfigTest {
 
   static ImmutableMap<String, String> parameters = ImmutableMap.of("table", "dataset.table");
   static ImmutableMap<String, String> emptyMap = ImmutableMap.of();
-  static String sparkVersion = "2.4.0";
+  static String sparkVersion = "2-4-7-aiq66";
 
   private static Map<String, String> asDataSourceOptionsMap(Map<String, String> map) {
     Map<String, String> result = new HashMap<>();

--- a/spark-bigquery-dsv2/spark-2.4-bigquery/pom.xml
+++ b/spark-bigquery-dsv2/spark-2.4-bigquery/pom.xml
@@ -13,7 +13,6 @@
     <version>${revision}</version>
     <name>BigQuery DataSource v2 for Spark 2.4</name>
     <properties>
-        <spark.version>2-4-7-aiq66</spark.version>
         <shade.skip>false</shade.skip>
     </properties>
     <licenses>

--- a/spark-bigquery-dsv2/spark-2.4-bigquery/pom.xml
+++ b/spark-bigquery-dsv2/spark-2.4-bigquery/pom.xml
@@ -13,7 +13,7 @@
     <version>${revision}</version>
     <name>BigQuery DataSource v2 for Spark 2.4</name>
     <properties>
-        <spark.version>2.4.0</spark.version>
+        <spark.version>2-4-7-aiq66</spark.version>
         <shade.skip>false</shade.skip>
     </properties>
     <licenses>

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/pom.xml
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>spark-bigquery-dsv2-common</artifactId>
     <name>BigQuery DataSource v2 implementation common implementation</name>
     <properties>
-        <spark.version>2.4.0</spark.version>
+        <spark.version>2-4-7-aiq66</spark.version>
     </properties>
     <licenses>
         <license>

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/pom.xml
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/pom.xml
@@ -11,9 +11,6 @@
 
     <artifactId>spark-bigquery-dsv2-common</artifactId>
     <name>BigQuery DataSource v2 implementation common implementation</name>
-    <properties>
-        <spark.version>2-4-7-aiq66</spark.version>
-    </properties>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
@@ -12,9 +12,6 @@
   <artifactId>spark-bigquery-dsv2-parent</artifactId>
   <name>BigQuery DataSource v2 implementation common settings</name>
   <packaging>pom</packaging>
-  <properties>
-    <spark.version>2-4-7-aiq66</spark.version>
-  </properties>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
@@ -13,7 +13,7 @@
   <name>BigQuery DataSource v2 implementation common settings</name>
   <packaging>pom</packaging>
   <properties>
-    <spark.version>2.4.0</spark.version>
+    <spark.version>2-4-7-aiq66</spark.version>
   </properties>
   <licenses>
     <license>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -110,6 +110,8 @@
         <deploy.skip>false</deploy.skip>
         <nexus.remote.skip>false</nexus.remote.skip>
         <shade.skip>true</shade.skip>
+        <spark.version>2-4-7-aiq66</spark.version>
+        <scala.binary.version>2.12</scala.binary.version>
         <!-- checkstyle
         <checkstyle.header.file>${reactor.project.basedir}/java.header</checkstyle.header.file>
         -->

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -51,6 +51,42 @@
         </site>
     </distributionManagement>
 
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Maven Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>aiq-releases-artifactory</id>
+            <name>Artifactory Releases</name>
+            <url>https://actioniq.jfrog.io/artifactory/aiq-sbt</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>aiq-releases-s3</id>
+            <name>AWS Releases Repository</name>
+            <url>s3://aiq-artifacts/releases</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <properties>
         <gpg.skip>true</gpg.skip>
         <revision>0.28.0-aiq10</revision>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -89,7 +89,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.28.0-aiq10</revision>
+        <revision>0.28.0-aiq11</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>10.0.1</arrow.version>

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/pom.xml
@@ -14,7 +14,6 @@
 
   <properties>
     <scala.binary.version>2.12</scala.binary.version>
-    <spark.version>2-4-7-aiq66</spark.version>
   </properties>
 
   <dependencies>

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <scala.binary.version>2.12</scala.binary.version>
-    <spark.version>2.4.0</spark.version>
+    <spark.version>2-4-7-aiq66</spark.version>
   </properties>
 
   <dependencies>

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <scala.binary.version>2.12</scala.binary.version>
-    <spark.version>3.1.0</spark.version>
+    <spark.version>2-4-7-aiq66</spark.version>
   </properties>
 
   <build>

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12/pom.xml
@@ -14,7 +14,6 @@
 
   <properties>
     <scala.binary.version>2.12</scala.binary.version>
-    <spark.version>2-4-7-aiq66</spark.version>
   </properties>
 
   <build>

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-parent/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-parent/pom.xml
@@ -14,10 +14,6 @@
   <name>Spark BigQuery Predicate Pushdown Implementation common settings</name>
 
   <packaging>pom</packaging>
-  <properties>
-    <scala.binary.version>2.12</scala.binary.version>
-    <spark.version>2-4-7-aiq66</spark.version>
-  </properties>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-parent/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-parent/pom.xml
@@ -15,8 +15,8 @@
 
   <packaging>pom</packaging>
   <properties>
-    <scala.binary.version>2.11</scala.binary.version>
-    <spark.version>2.4.0</spark.version>
+    <scala.binary.version>2.12</scala.binary.version>
+    <spark.version>2-4-7-aiq66</spark.version>
   </properties>
   <licenses>
     <license>

--- a/spark-bigquery-scala-212-support/pom.xml
+++ b/spark-bigquery-scala-212-support/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.12</artifactId>
-            <version>3.2.0</version>
+            <version>2-4-7-aiq66</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/spark-bigquery-scala-212-support/pom.xml
+++ b/spark-bigquery-scala-212-support/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.12</artifactId>
-            <version>2-4-7-aiq66</version>
+            <version>${spark.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/spark-bigquery-tests/pom.xml
+++ b/spark-bigquery-tests/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_2.12</artifactId>
-      <version>2.4.0</version>
+      <version>2-4-7-aiq66</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/spark-bigquery-tests/pom.xml
+++ b/spark-bigquery-tests/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_2.12</artifactId>
-      <version>2-4-7-aiq66</version>
+      <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
https://actioniq.atlassian.net/browse/EXE-1966

`./mvnw dependency:tree` to make sure all `org.apache.spark` artifacts are of `2-4-7-aiq66` version, instead of 2.4

Ran ` ./mvnw clean test -fn` off this branch and branch-0.28, compared the failures: all new test failures happened in `spark-bigquery-connector-common` package, which seems to be related to changing spark scala version from 2.12 to 2.13

This one should be fine since we are on scala 2.12:
```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.137 s <<< FAILURE! - in org.apache.spark.sql.Scala213SparkSqlUtilsTest
[ERROR] org.apache.spark.sql.Scala213SparkSqlUtilsTest.testRowToInternalRow  Time elapsed: 0.082 s  <<< ERROR!
java.lang.IllegalArgumentException: Could not load instance of 'org.apache.spark.sql.SparkSqlUtils', please check the META-INF/services directory in the connector's jar
	at org.apache.spark.sql.SparkSqlUtils.lambda$getInstance$1(SparkSqlUtils.java:38)
	at java.util.Optional.orElseThrow(Optional.java:290)
	at org.apache.spark.sql.SparkSqlUtils.getInstance(SparkSqlUtils.java:35)
	at org.apache.spark.sql.Scala213SparkSqlUtilsTest.testRowToInternalRow(Scala213SparkSqlUtilsTest.java:29)
```

This one failed with the same error as ^, but it's only for writing which we don't need:
```
23/09/19 17:59:35 WARN DataSourceWriterContextPartitionHandler: Encountered error writing partition 0 in task id 0 for epoch 1000. Calling DataWriter.abort()
java.lang.IllegalArgumentException: Could not load instance of 'org.apache.spark.sql.SparkSqlUtils', please check the META-INF/services directory in the connector's jar
	at org.apache.spark.sql.SparkSqlUtils.lambda$getInstance$1(SparkSqlUtils.java:38)
	at java.util.Optional.orElseThrow(Optional.java:290)
	at org.apache.spark.sql.SparkSqlUtils.getInstance(SparkSqlUtils.java:35)
	at com.google.cloud.spark.bigquery.write.DataSourceWriterContextPartitionHandler.call(DataSourceWriterContextPartitionHandler.java:60)
	at com.google.cloud.spark.bigquery.write.DataSourceWriterContextPartitionHandlerTest.testGoodWrite(DataSourceWriterContextPartitionHandlerTest.java:64)
```

`./mvnw deploy -DskipTests` to deploy aiq11, pulled the deployed artifact to flame and tested with spark-shell:
```
com.google.cloud.spark.bigquery.BigQueryConnectorUtils.enablePushdownSession(spark)
val r1 = spark.read.format("bigquery").option("parentProject", "aiq-dev").option("credentialsFile", "/Users/dongyingzhou/Downloads/aiq-dev-e0ad53189782.json").option("materializationDataset", "connector_dev").option("dataset", "connector_dev").option("materializationExpirationTimeInMinutes", 60)
r1.load("aiq-dev.connector_dev.dim_customer").createOrReplaceTempView("c")
spark.sql("select first_name from c where state = 'NY'").queryExecution.sparkPlan
spark.sql("select first_name from c where state = 'NY'").count()
```
Verified from BigQuery console that the queries were executed as expected
