### PR TITLE
[EXE-1966][Spark 3] Use aiq flame

### DIFF
--- a/README.md
+++ b/README.md
@@ -1304,17 +1304,44 @@ This places artifacts in `~/.m2/repository/`
 ./mvnw clean install
 ```
 
-# Tests
+# Unit Tests
 Run all tests except acceptance test and integration tests
 ```
 ./mvnw test -fn
 ```
 
-Acceptance Tests and Integration Tests need additional GCP settings
+# Integration Tests
+To run integration test with `aiq-dev` BigQuery instance, download the service account credentials to a local
+file, then run
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=<path_to_the_file>
+export GOOGLE_CLOUD_PROJECT=aiq-dev
 ```
-./mvnw integration-test -P acceptance
-./mvnw integration-test -P integration
+
+Run integration tests:
+```bash
+# make sure to do this after updating tests - for some reason failsafe:integration-test doesn't compile tests before running
+./mvnw install -Pintegration -DskipTests
+
+# Test pushdown statements
+./mvnw failsafe:integration-test -fn \
+  -Dfailsafe.failIfNoSpecifiedTests=false \
+  -Dit.test=com.google.cloud.spark.bigquery.integration.Spark33QueryPushdownIntegrationTest
+
+# Test read
+./mvnw failsafe:integration-test -fn \
+  -Dfailsafe.failIfNoSpecifiedTests=false \
+  -Dit.test=com.google.cloud.spark.bigquery.integration.Spark33ReadFromQueryIntegrationTest
+
+./mvnw failsafe:integration-test -fn \
+  -Dfailsafe.failIfNoSpecifiedTests=false \
+  -Dit.test=com.google.cloud.spark.bigquery.integration.Spark33ReadIntegrationTest
 ```
+
+If tests failed, there might be some residual testing datasets named with `spark_bigquery_<ts>_<number>`
+left in `aiq-dev` project. Remember to delete them.
+
+TODO figure out acceptance test
 
 # Deploy
 To deploy to AIQ artifactory https://actioniq.jfrog.io/artifactory/aiq-sbt-local

--- a/spark-bigquery-connector-common/pom.xml
+++ b/spark-bigquery-connector-common/pom.xml
@@ -40,8 +40,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.13</artifactId>
-            <version>3.3.0</version>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -52,8 +52,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-mllib_2.13</artifactId>
-            <version>3.3.0</version>
+            <artifactId>spark-mllib_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/spark-bigquery-connector-common/src/main/java/org/apache/spark/sql/Scala212SparkSqlUtils.java
+++ b/spark-bigquery-connector-common/src/main/java/org/apache/spark/sql/Scala212SparkSqlUtils.java
@@ -1,0 +1,62 @@
+package org.apache.spark.sql;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer$;
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder;
+import org.apache.spark.sql.catalyst.encoders.RowEncoder;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
+import org.apache.spark.sql.catalyst.expressions.AttributeReference;
+import org.apache.spark.sql.catalyst.expressions.NamedExpression;
+import org.apache.spark.sql.types.StructType;
+import scala.collection.JavaConverters;
+import scala.collection.mutable.ListBuffer;
+
+/** Copy-pasted from [[PreScala213SparkSqlUtils]] */
+public class Scala212SparkSqlUtils extends SparkSqlUtils {
+  @Override
+  public boolean supportsScalaVersion(String scalaVersion) {
+    return scalaVersion.compareTo("2.13") < 0;
+  }
+
+  @Override
+  public InternalRow rowToInternalRow(Row row) {
+    return InternalRow.fromSeq(row.toSeq());
+  }
+
+  // This method relies on the scala.Seq alias, which is different in Scala 2.12 and 2.13. In Scala
+  // 2.12 scala.Seq points to scala.collection.Seq whereas in Scala 2.13 it points to
+  // scala.collection.immutable.Seq.   @Override
+  public ExpressionEncoder<Row> createExpressionEncoder(StructType schema) {
+    List<Attribute> attributes =
+        JavaConverters.asJavaCollection(toAttributes(schema)).stream()
+            .map(Attribute::toAttribute)
+            .collect(Collectors.toList());
+    ExpressionEncoder<Row> expressionEncoder =
+        RowEncoder.apply(schema)
+            .resolveAndBind(
+                JavaConverters.asScalaIteratorConverter(attributes.iterator()).asScala().toSeq(),
+                SimpleAnalyzer$.MODULE$);
+    return expressionEncoder;
+  }
+
+  // `toAttributes` is protected[sql] starting spark 3.2.0, so we need this call to be in the same
+  // package. Since Scala 2.13/Spark 3.3 forbids it, the implementation has been ported to Java
+  public static scala.collection.Seq<AttributeReference> toAttributes(StructType schema) {
+    List<AttributeReference> result =
+        Stream.of(schema.fields())
+            .map(
+                field ->
+                    new AttributeReference(
+                        field.name(),
+                        field.dataType(),
+                        field.nullable(),
+                        field.metadata(),
+                        NamedExpression.newExprId(),
+                        new ListBuffer<String>().toSeq()))
+            .collect(Collectors.toList());
+    return JavaConverters.asScalaBuffer(result).toSeq();
+  }
+}

--- a/spark-bigquery-connector-common/src/main/java/org/apache/spark/sql/Scala213SparkSqlUtils.java
+++ b/spark-bigquery-connector-common/src/main/java/org/apache/spark/sql/Scala213SparkSqlUtils.java
@@ -73,6 +73,8 @@ public class Scala213SparkSqlUtils extends SparkSqlUtils {
                         NamedExpression.newExprId(),
                         new ListBuffer<String>().toSeq()))
             .collect(Collectors.toList());
-    return JavaConverters.asScalaBuffer(result).toSeq();
+    return (scala.collection.immutable.Seq<
+            org.apache.spark.sql.catalyst.expressions.AttributeReference>)
+        scala.collection.JavaConverters.asScalaBuffer(result).toSeq();
   }
 }

--- a/spark-bigquery-connector-common/src/main/java/org/apache/spark/sql/SparkSqlUtils.java
+++ b/spark-bigquery-connector-common/src/main/java/org/apache/spark/sql/SparkSqlUtils.java
@@ -36,7 +36,7 @@ public abstract class SparkSqlUtils {
                   () ->
                       new IllegalArgumentException(
                           String.format(
-                              "Could not load instance of '%', please check the META-INF/services directory in the connector's jar",
+                              "Could not load instance of '%s', please check the META-INF/services directory in the connector's jar",
                               SparkSqlUtils.class.getCanonicalName())));
     }
     return instance;

--- a/spark-bigquery-connector-common/src/main/resources/META-INF/services/org.apache.spark.sql.SparkSqlUtils
+++ b/spark-bigquery-connector-common/src/main/resources/META-INF/services/org.apache.spark.sql.SparkSqlUtils
@@ -1,1 +1,2 @@
 org.apache.spark.sql.Scala213SparkSqlUtils
+org.apache.spark.sql.Scala212SparkSqlUtils

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -953,7 +953,7 @@ public class SparkBigQueryConfigTest {
     assertThat(before24.getMessage()).contains("com.databricks:spark-avro_2.11:4.0.0");
     IllegalStateException after24 =
         SparkBigQueryConfig.IntermediateFormat.missingAvroException("2.4.8", cause);
-    assertThat(after24.getMessage()).contains("org.apache.spark:spark-avro_2.13:2.4.8");
+    assertThat(after24.getMessage()).contains("org.apache.spark:spark-avro_2.12:2.4.8");
   }
 
   @Test

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -50,7 +50,7 @@ import org.junit.Test;
 public class SparkBigQueryConfigTest {
 
   public static final int DEFAULT_PARALLELISM = 10;
-  public static final String SPARK_VERSION = "2.4.0";
+  public static final String SPARK_VERSION = "3-3-2-aiq35";
   private static ImmutableMap<String, String> build;
   ImmutableMap<String, String> defaultOptions = ImmutableMap.of("table", "dataset.table");
   // "project", "test_project"); // to remove the need for default project
@@ -487,7 +487,7 @@ public class SparkBigQueryConfigTest {
 
   static ImmutableMap<String, String> parameters = ImmutableMap.of("table", "dataset.table");
   static ImmutableMap<String, String> emptyMap = ImmutableMap.of();
-  static String sparkVersion = "2.4.0";
+  static String sparkVersion = "3-3-2-aiq35";
 
   private static Map<String, String> asDataSourceOptionsMap(Map<String, String> map) {
     Map<String, String> result = new HashMap<>();

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/direct/Scala213BigQueryRDDTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/direct/Scala213BigQueryRDDTest.java
@@ -20,11 +20,13 @@ import static com.google.common.truth.Truth.assertThat;
 import org.apache.spark.rdd.RDD;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class Scala213BigQueryRDDTest {
 
   @Test
+  @Ignore("aiq: spark 2.13 not in use")
   public void testCreateScala213BigQueryRDD() throws Exception {
     SparkSession sparkSession =
         SparkSession.builder().master("local").appName(getClass().getName()).getOrCreate();

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
@@ -410,17 +410,20 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
   }
 
   @Test
+  @Ignore("aiq")
   public void testReadFromBigLakeTable_csv() {
     testBigLakeTable(FormatOptions.csv(), TestConstants.SHAKESPEARE_CSV_FILENAME, "text/csv");
   }
 
   @Test
+  @Ignore("aiq")
   public void testReadFromBigLakeTable_json() {
     testBigLakeTable(
         FormatOptions.json(), TestConstants.SHAKESPEARE_JSON_FILENAME, "application/json");
   }
 
   @Test
+  @Ignore("aiq")
   public void testReadFromBigLakeTable_parquet() {
     testBigLakeTable(
         FormatOptions.parquet(),
@@ -429,6 +432,7 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
   }
 
   @Test
+  @Ignore("aiq")
   public void testReadFromBigLakeTable_avro() {
     testBigLakeTable(
         FormatOptions.avro(), TestConstants.SHAKESPEARE_AVRO_FILENAME, "application/octet-stream");

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/SparkBigQueryIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/SparkBigQueryIntegrationTestBase.java
@@ -48,7 +48,7 @@ public class SparkBigQueryIntegrationTestBase {
               .config("spark.ui.enabled", "false")
               .config("spark.default.parallelism", 20)
               .getOrCreate();
-      // reducing test's logs
+      // helpful for checking queries running in BQ
       spark.sparkContext().setLogLevel("INFO");
     }
   }

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/SparkBigQueryIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/SparkBigQueryIntegrationTestBase.java
@@ -44,12 +44,12 @@ public class SparkBigQueryIntegrationTestBase {
     protected void before() throws Throwable {
       spark =
           SparkSession.builder()
-              .master("local")
+              .master("local[*]")
               .config("spark.ui.enabled", "false")
               .config("spark.default.parallelism", 20)
               .getOrCreate();
       // reducing test's logs
-      spark.sparkContext().setLogLevel("WARN");
+      spark.sparkContext().setLogLevel("INFO");
     }
   }
 

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/TestConstants.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/TestConstants.java
@@ -72,8 +72,8 @@ public class TestConstants {
   static final long SHAKESPEARE_TABLE_NUM_ROWS = 164656L;
   static final String TEMPORARY_GCS_BUCKET_ENV_VARIABLE = "TEMPORARY_GCS_BUCKET";
   static final String BIGLAKE_CONNECTION_ID_ENV_VARIABLE = "BIGLAKE_CONNECTION_ID";
-  static final String TEMPORARY_GCS_BUCKET = "";
-  static final String BIGLAKE_CONNECTION_ID = "";
+  static final String TEMPORARY_GCS_BUCKET = System.getenv(TEMPORARY_GCS_BUCKET_ENV_VARIABLE);
+  static final String BIGLAKE_CONNECTION_ID = System.getenv(BIGLAKE_CONNECTION_ID_ENV_VARIABLE);
   static final String SHAKESPEARE_CSV_FILENAME = "shakespeare.csv";
   static final String SHAKESPEARE_JSON_FILENAME = "shakespeare.json";
   static final String SHAKESPEARE_AVRO_FILENAME = "shakespeare.avro";

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/TestConstants.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/TestConstants.java
@@ -35,7 +35,6 @@ import static org.apache.spark.sql.types.DataTypes.TimestampType;
 import com.google.cloud.spark.bigquery.integration.model.ColumnOrderTestClass;
 import com.google.cloud.spark.bigquery.integration.model.NumStruct;
 import com.google.cloud.spark.bigquery.integration.model.StringStruct;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.math.BigDecimal;
 import java.math.MathContext;
@@ -73,15 +72,8 @@ public class TestConstants {
   static final long SHAKESPEARE_TABLE_NUM_ROWS = 164656L;
   static final String TEMPORARY_GCS_BUCKET_ENV_VARIABLE = "TEMPORARY_GCS_BUCKET";
   static final String BIGLAKE_CONNECTION_ID_ENV_VARIABLE = "BIGLAKE_CONNECTION_ID";
-  static final String TEMPORARY_GCS_BUCKET =
-      Preconditions.checkNotNull(
-          System.getenv(TEMPORARY_GCS_BUCKET_ENV_VARIABLE),
-          "Please set the %s env variable to point to a write enabled GCS bucket",
-          TEMPORARY_GCS_BUCKET_ENV_VARIABLE);
-  static final String BIGLAKE_CONNECTION_ID =
-      Preconditions.checkNotNull(
-          System.getenv(BIGLAKE_CONNECTION_ID_ENV_VARIABLE),
-          "Please set the BIGLAKE_CONNECTION_ID env variable in order to create biglake table");
+  static final String TEMPORARY_GCS_BUCKET = "";
+  static final String BIGLAKE_CONNECTION_ID = "";
   static final String SHAKESPEARE_CSV_FILENAME = "shakespeare.csv";
   static final String SHAKESPEARE_JSON_FILENAME = "shakespeare.json";
   static final String SHAKESPEARE_AVRO_FILENAME = "shakespeare.avro";

--- a/spark-bigquery-connector-common/src/test/java/org/apache/spark/sql/Scala212SparkSqlUtilsTest.java
+++ b/spark-bigquery-connector-common/src/test/java/org/apache/spark/sql/Scala212SparkSqlUtilsTest.java
@@ -1,0 +1,22 @@
+package org.apache.spark.sql;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericRow;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.Test;
+
+/** Copy-pasted from [[PreScala213SparkSqlUtilsTest]] */
+public class Scala212SparkSqlUtilsTest {
+  @Test
+  public void testRowToInternalRow() throws Exception {
+    SparkSqlUtils ssu = SparkSqlUtils.getInstance();
+    assertThat(ssu).isInstanceOf(Scala212SparkSqlUtils.class);
+    Row row = new GenericRow(new Object[] {UTF8String.fromString("a"), 1});
+    InternalRow internalRow = ssu.rowToInternalRow(row);
+    assertThat(internalRow.numFields()).isEqualTo(2);
+    assertThat(internalRow.getString(0).toString()).isEqualTo("a");
+    assertThat(internalRow.getInt(1)).isEqualTo(1);
+  }
+}

--- a/spark-bigquery-connector-common/src/test/java/org/apache/spark/sql/Scala213SparkSqlUtilsTest.java
+++ b/spark-bigquery-connector-common/src/test/java/org/apache/spark/sql/Scala213SparkSqlUtilsTest.java
@@ -20,11 +20,13 @@ import static com.google.common.truth.Truth.assertThat;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericRow;
 import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class Scala213SparkSqlUtilsTest {
 
   @Test
+  @Ignore("aiq: spark 2.13 not in use")
   public void testRowToInternalRow() throws Exception {
     SparkSqlUtils ssu = SparkSqlUtils.getInstance();
     assertThat(ssu).isInstanceOf(Scala213SparkSqlUtils.class);

--- a/spark-bigquery-dsv2/spark-3.3-bigquery-lib/pom.xml
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery-lib/pom.xml
@@ -13,7 +13,6 @@
   <version>${revision}</version>
   <name>Connector code for BigQuery DataSource v2 for Spark 3.3</name>
   <properties>
-    <spark.version>3.3.2</spark.version>
     <shade.skip>true</shade.skip>
   </properties>
   <licenses>

--- a/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/pom.xml
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery_2.12/pom.xml
@@ -13,9 +13,7 @@
   <version>${revision}</version>
   <name>BigQuery DataSource v2 for Spark 3.3, Scala 2.12</name>
   <properties>
-    <spark.version>3.3.2</spark.version>
     <shade.skip>false</shade.skip>
-    <scala.binary.version>2.12</scala.binary.version>
   </properties>
   <licenses>
     <license>

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/pom.xml
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/pom.xml
@@ -11,9 +11,6 @@
 
     <artifactId>spark-bigquery-dsv2-common</artifactId>
     <name>BigQuery DataSource v2 implementation common implementation</name>
-    <properties>
-        <spark.version>2.4.0</spark.version>
-    </properties>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
@@ -12,10 +12,6 @@
   <artifactId>spark-bigquery-dsv2-parent</artifactId>
   <name>BigQuery DataSource v2 implementation common settings</name>
   <packaging>pom</packaging>
-  <properties>
-    <spark.version>2.4.0</spark.version>
-    <scala.binary.version>2.12</scala.binary.version>
-  </properties>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -47,6 +47,42 @@
         </repository>
     </distributionManagement>
 
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Maven Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>aiq-releases-artifactory</id>
+            <name>Artifactory Releases</name>
+            <url>https://actioniq.jfrog.io/artifactory/aiq-sbt</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>aiq-releases-s3</id>
+            <name>AWS Releases Repository</name>
+            <url>s3://aiq-artifacts/releases</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <properties>
         <gpg.skip>true</gpg.skip>
         <revision>0.30.0-aiq4</revision>
@@ -75,6 +111,9 @@
         <!-- checkstyle
         <checkstyle.header.file>${reactor.project.basedir}/java.header</checkstyle.header.file>
         -->
+        <spark.version>3-3-2-aiq35</spark.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <scala.patch.version>15</scala.patch.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -85,7 +85,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq4</revision>
+        <revision>0.30.0-aiq5</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>
@@ -106,7 +106,22 @@
         <nexus.remote.skip>false</nexus.remote.skip>
         <shade.skip>true</shade.skip>
         <argLine>
+            <!-- https://github.com/ActionIQ/flame/blob/3.3/pom.xml#L309C1-L323C48 -->
+            --add-opens=java.base/java.lang=ALL-UNNAMED
+            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+            --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+            --add-opens=java.base/java.io=ALL-UNNAMED
+            --add-opens=java.base/java.net=ALL-UNNAMED
+            --add-opens=java.base/java.nio=ALL-UNNAMED
+            --add-opens=java.base/java.util=ALL-UNNAMED
+            --add-opens=java.base/java.time=ALL-UNNAMED
+            --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+            --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
             --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+            --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
+            --add-opens=java.base/sun.security.action=ALL-UNNAMED
+            --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+            --add-opens=java.sql/java.sql=ALL-UNNAMED
         </argLine>
         <!-- checkstyle
         <checkstyle.header.file>${reactor.project.basedir}/java.header</checkstyle.header.file>

--- a/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12/pom.xml
@@ -12,12 +12,6 @@
 
   <artifactId>spark-3.3-bigquery-pushdown_2.12</artifactId>
 
-  <properties>
-    <scala.binary.version>2.12</scala.binary.version>
-    <scala.patch.version>15</scala.patch.version>
-    <spark.version>3.3.2</spark.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12/pom.xml
@@ -12,12 +12,6 @@
 
   <artifactId>spark-bigquery-pushdown-common_2.12</artifactId>
 
-  <properties>
-    <scala.binary.version>2.12</scala.binary.version>
-    <scala.patch.version>15</scala.patch.version>
-    <spark.version>3.3.2</spark.version>
-  </properties>
-
   <build>
     <plugins>
       <!-- make sure we don't have any _2.10 or _2.11 or _2.13 dependencies when building

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-parent/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-parent/pom.xml
@@ -14,11 +14,6 @@
   <name>Spark BigQuery Predicate Pushdown Implementation common settings</name>
 
   <packaging>pom</packaging>
-  <properties>
-    <scala.binary.version>2.11</scala.binary.version>
-    <scala.patch.version>0</scala.patch.version>
-    <spark.version>2.4.0</spark.version>
-  </properties>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>

--- a/spark-bigquery-scala-212-support/pom.xml
+++ b/spark-bigquery-scala-212-support/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.12</artifactId>
-            <version>3.2.0</version>
+            <version>${spark.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/spark-bigquery-tests/pom.xml
+++ b/spark-bigquery-tests/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_2.12</artifactId>
-      <version>2.4.0</version>
+      <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Setting up dependencies on aiq flame instead of generic spark artifacts;

Specifying spark version to be aiq flame version, and scala version to be 2.12; 

Fixing a class loading issue introduced by changing from scala 2.12 to scala 2.13 in `spark-bigquery-connector-common/src/main/java/org/apache/spark/sql/SparkSqlUtils.java`: there's a `spark-bigquery-scala-212-support/src/main/java/org/apache/spark/sql/PreScala213SparkSqlUtils` that extends `SparkSqlUtils`, which is supposed to be used when scala version is 2.12. For some reason PreScala213SparkSqlUtils was not loaded in test: 
```
java.lang.IllegalArgumentException: Could not load instance of 'org.apache.spark.sql.SparkSqlUtils', please check the META-INF/services directory in the connector's jar
	at org.apache.spark.sql.SparkSqlUtils.lambda$getInstance$1(SparkSqlUtils.java:38)
	at java.util.Optional.orElseThrow(Optional.java:290)
	at org.apache.spark.sql.SparkSqlUtils.getInstance(SparkSqlUtils.java:35)
	at com.google.cloud.spark.bigquery.write.DataSourceWriterContextPartitionHandler.call(DataSourceWriterContextPartitionHandler.java:60)
```
so copy-pasting this class to `spark-bigquery-connector-common` artifact to make sure it works with scala 2.12

Fixing some test issues; adding README for integration test

Ran `./mvnw dependency:tree` to make sure that all `org.apache.spark` artifacts are replaced by aiq flame (except the ones in `spark-3.1-bigquery-lib` and `spark-3.2-bigquery-lib`)

Ran unit tests and integration tests (see README)

Bumped version and installed locally, pulled into flame33 and tested reading from BigQuery in spark shell
```
com.google.cloud.spark.bigquery.BigQueryConnectorUtils.enablePushdownSession(spark)
val r1 = spark.read.format("bigquery").option("parentProject", "aiq-dev").option("credentialsFile", "/Users/dongyingzhou/Downloads/aiq-dev-e0ad53189782.json").option("materializationDataset", "connector_dev").option("dataset", "connector_dev").option("materializationExpirationTimeInMinutes", 60)

scala> spark.sql("select first_name from c where state = 'NY'").queryExecution.sparkPlan
res4: org.apache.spark.sql.execution.SparkPlan =
Spark33BigQueryPushdownPlan [SUBQUERY_3_COL_0#34], PreScala213BigQueryRDD[3] at RDD at PreScala213BigQueryRDD.java:74, SELECT ( SUBQUERY_2.FIRST_NAME ) AS SUBQUERY_3_COL_0 FROM ( SELECT * FROM ( SELECT * FROM `aiq-dev.connector_dev.dim_customer` AS BQ_CONNECTOR_QUERY_ALIAS WHERE (`state` = 'NY' AND `state` IS NOT NULL) ) AS SUBQUERY_1 WHERE ( ( SUBQUERY_1.STATE IS NOT NULL ) AND ( SUBQUERY_1.STATE = 'NY' ) ) ) AS SUBQUERY_2

scala> spark.sql("select first_name from c where state = 'NY'").count()
res5: Long = 335598
```