### PR TITLE
[EXE-1966][Spark 2] Fix scala 2.12 class loading issue

### DIFF
--- a/spark-bigquery-connector-common/src/main/java/org/apache/spark/sql/Scala212SparkSqlUtils.java
+++ b/spark-bigquery-connector-common/src/main/java/org/apache/spark/sql/Scala212SparkSqlUtils.java
@@ -1,0 +1,62 @@
+package org.apache.spark.sql;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer$;
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder;
+import org.apache.spark.sql.catalyst.encoders.RowEncoder;
+import org.apache.spark.sql.catalyst.expressions.Attribute;
+import org.apache.spark.sql.catalyst.expressions.AttributeReference;
+import org.apache.spark.sql.catalyst.expressions.NamedExpression;
+import org.apache.spark.sql.types.StructType;
+import scala.collection.JavaConverters;
+import scala.collection.mutable.ListBuffer;
+
+/** Copy-pasted from [[PreScala213SparkSqlUtils]] */
+public class Scala212SparkSqlUtils extends SparkSqlUtils {
+  @Override
+  public boolean supportsScalaVersion(String scalaVersion) {
+    return scalaVersion.compareTo("2.13") < 0;
+  }
+
+  @Override
+  public InternalRow rowToInternalRow(Row row) {
+    return InternalRow.fromSeq(row.toSeq());
+  }
+
+  // This method relies on the scala.Seq alias, which is different in Scala 2.12 and 2.13. In Scala
+  // 2.12 scala.Seq points to scala.collection.Seq whereas in Scala 2.13 it points to
+  // scala.collection.immutable.Seq.   @Override
+  public ExpressionEncoder<Row> createExpressionEncoder(StructType schema) {
+    List<Attribute> attributes =
+        JavaConverters.asJavaCollection(toAttributes(schema)).stream()
+            .map(Attribute::toAttribute)
+            .collect(Collectors.toList());
+    ExpressionEncoder<Row> expressionEncoder =
+        RowEncoder.apply(schema)
+            .resolveAndBind(
+                JavaConverters.asScalaIteratorConverter(attributes.iterator()).asScala().toSeq(),
+                SimpleAnalyzer$.MODULE$);
+    return expressionEncoder;
+  }
+
+  // `toAttributes` is protected[sql] starting spark 3.2.0, so we need this call to be in the same
+  // package. Since Scala 2.13/Spark 3.3 forbids it, the implementation has been ported to Java
+  public static scala.collection.Seq<AttributeReference> toAttributes(StructType schema) {
+    List<AttributeReference> result =
+        Stream.of(schema.fields())
+            .map(
+                field ->
+                    new AttributeReference(
+                        field.name(),
+                        field.dataType(),
+                        field.nullable(),
+                        field.metadata(),
+                        NamedExpression.newExprId(),
+                        new ListBuffer<String>().toSeq()))
+            .collect(Collectors.toList());
+    return JavaConverters.asScalaBuffer(result).toSeq();
+  }
+}

--- a/spark-bigquery-connector-common/src/main/resources/META-INF/services/org.apache.spark.sql.SparkSqlUtils
+++ b/spark-bigquery-connector-common/src/main/resources/META-INF/services/org.apache.spark.sql.SparkSqlUtils
@@ -1,1 +1,2 @@
 org.apache.spark.sql.Scala213SparkSqlUtils
+org.apache.spark.sql.Scala212SparkSqlUtils

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -925,11 +925,11 @@ public class SparkBigQueryConfigTest {
   public void testMissingAvroMessage() {
     Exception cause = new Exception("test");
     IllegalStateException before24 =
-        SparkBigQueryConfig.IntermediateFormat.missingAvroException("2.3.5", cause);
+        SparkBigQueryConfig.IntermediateFormat.missingAvroException("2-3-5-aiq1", cause);
     assertThat(before24.getMessage()).contains("com.databricks:spark-avro_2.11:4.0.0");
     IllegalStateException after24 =
-        SparkBigQueryConfig.IntermediateFormat.missingAvroException("2.4.8", cause);
-    assertThat(after24.getMessage()).contains("org.apache.spark:spark-avro_2.13:2.4.8");
+        SparkBigQueryConfig.IntermediateFormat.missingAvroException("2-4-7-aiq2", cause);
+    assertThat(after24.getMessage()).contains("org.apache.spark:spark-avro_2.12:2-4-7-aiq2");
   }
 
   @Test

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/direct/Scala213BigQueryRDDTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/direct/Scala213BigQueryRDDTest.java
@@ -20,11 +20,13 @@ import static com.google.common.truth.Truth.assertThat;
 import org.apache.spark.rdd.RDD;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class Scala213BigQueryRDDTest {
 
   @Test
+  @Ignore("aiq scala 2.13 not in use")
   public void testCreateScala213BigQueryRDD() throws Exception {
     SparkSession sparkSession =
         SparkSession.builder().master("local").appName(getClass().getName()).getOrCreate();

--- a/spark-bigquery-connector-common/src/test/java/org/apache/spark/sql/Scala212SparkSqlUtilsTest.java
+++ b/spark-bigquery-connector-common/src/test/java/org/apache/spark/sql/Scala212SparkSqlUtilsTest.java
@@ -1,0 +1,22 @@
+package org.apache.spark.sql;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericRow;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.Test;
+
+/** Copy-pasted from [[PreScala213SparkSqlUtilsTest]] */
+public class Scala212SparkSqlUtilsTest {
+  @Test
+  public void testRowToInternalRow() throws Exception {
+    SparkSqlUtils ssu = SparkSqlUtils.getInstance();
+    assertThat(ssu).isInstanceOf(Scala212SparkSqlUtils.class);
+    Row row = new GenericRow(new Object[] {UTF8String.fromString("a"), 1});
+    InternalRow internalRow = ssu.rowToInternalRow(row);
+    assertThat(internalRow.numFields()).isEqualTo(2);
+    assertThat(internalRow.getString(0).toString()).isEqualTo("a");
+    assertThat(internalRow.getInt(1)).isEqualTo(1);
+  }
+}

--- a/spark-bigquery-connector-common/src/test/java/org/apache/spark/sql/Scala213SparkSqlUtilsTest.java
+++ b/spark-bigquery-connector-common/src/test/java/org/apache/spark/sql/Scala213SparkSqlUtilsTest.java
@@ -20,11 +20,13 @@ import static com.google.common.truth.Truth.assertThat;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericRow;
 import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class Scala213SparkSqlUtilsTest {
 
   @Test
+  @Ignore("aiq scala 2.13 not in use")
   public void testRowToInternalRow() throws Exception {
     SparkSqlUtils ssu = SparkSqlUtils.getInstance();
     assertThat(ssu).isInstanceOf(Scala213SparkSqlUtils.class);

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -89,7 +89,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.28.0-aiq12</revision>
+        <revision>0.28.0-aiq13</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>10.0.1</arrow.version>


### PR DESCRIPTION
Followup of https://github.com/ActionIQ/spark-bigquery-connector/pull/8

Fixing the issue of loading `PreScala213SparkSqlUtils` by copy-pasting the implementations to `spark-bigquery-connector-common`. See details in the [corresponding spark 3 PR](https://github.com/ActionIQ/spark-bigquery-connector/pull/10)

Some other random test fixes 