### PR TITLE
[EXE-1951][Spark 3] Implement aiq_day_diff pushdown

### DIFF
--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
@@ -1082,6 +1082,35 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
+  @Test
+  /**
+   * Reading from a BigQuery table created with: create or replace table aiq-dev.connector_dev.dt (
+   * id integer, ts1 integer, ts2 integer, tz string );
+   *
+   * <p>insert `aiq-dev.connector_dev.dt` values (0, unix_millis(timestamp("2023-09-01T23:59:59")),
+   * unix_millis(timestamp("2023-09-02T00:00:00")),"UTC"), (1,
+   * unix_millis(timestamp("2023-09-01T23:59:59")),
+   * unix_millis(timestamp("2023-09-02T00:00:00")),"America/New_York"), (2,
+   * unix_millis(timestamp("2023-09-01T23:59:59")),
+   * unix_millis(timestamp("2023-09-02T00:00:00")),"Asia/Shanghai");
+   */
+  public void testAiqDayDiff() {
+    Dataset<Row> df = readTestDataFromBigQuery("connector_dev.dt");
+    df.createOrReplaceTempView("dt");
+    // INSERT might not follow the exact order
+    List<Row> diffs1 =
+        spark.sql("select aiq_day_diff(ts1, ts2, tz) from dt order by id").collectAsList();
+    assertThat(diffs1.size()).isEqualTo(3);
+    assertThat(diffs1.get(0).get(0)).isEqualTo(1);
+    assertThat(diffs1.get(1).get(0)).isEqualTo(0);
+    assertThat(diffs1.get(2).get(0)).isEqualTo(0);
+    List<Row> diff2 =
+        spark
+            .sql("select aiq_day_diff(ts1, unix_timestamp() * 1000, 'UTC') from dt")
+            .collectAsList();
+    assert ((int) diff2.get(0).get(0) > 10); // 2023-09-01 to current
+  }
+
   /** Creating a Dataset of NumStructType which will be used to write to BigQuery */
   protected Dataset<Row> getNumStructDataFrame(List<NumStruct> numStructList) {
     return spark.createDataset(numStructList, Encoders.bean(NumStruct.class)).toDF();

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -85,7 +85,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq5</revision>
+        <revision>0.30.0-aiq6</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
@@ -215,6 +215,20 @@ abstract class SparkExpressionConverter {
           blockStatement(
             convertStatement(date, fields) + s", ${format.toString()}"
           )
+      /**
+       * aiq_day_diff(startTsExpr, endTsExpr, timezoneExpr) =>
+       * DATE_DIFF(
+       *   DATE(TIMESTAMP_MILLIS(endTsExpr), timezoneExpr),
+       *   DATE(TIMESTAMP_MILLIS(startTsExpr), timezoneExpr),
+       *   DAY
+       * )
+       */
+      case AiqDayDiff(startMs, endMs, timezoneId) =>
+        val startTs = ConstantString("TIMESTAMP_MILLIS") + blockStatement(convertStatement(startMs, fields))
+        val startDt = ConstantString("DATE") + blockStatement(startTs + "," + convertStatement(timezoneId, fields))
+        val endTs = ConstantString("TIMESTAMP_MILLIS") + blockStatement(convertStatement(endMs, fields))
+        val endDt = ConstantString("DATE") + blockStatement(endTs + "," + convertStatement(timezoneId, fields))
+        ConstantString("DATE_DIFF") + blockStatement(endDt + "," + startDt + "," + "DAY")
 
       case _ => null
     })

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
@@ -4,7 +4,7 @@ import com.google.cloud.bigquery.connector.common.BigQueryPushdownUnsupportedExc
 import com.google.cloud.spark.bigquery.direct.DirectBigQueryRelation
 import com.google.cloud.spark.bigquery.pushdowns.TestConstants.expressionConverter
 import org.apache.spark.sql.catalyst.expressions.aggregate._
-import org.apache.spark.sql.catalyst.expressions.{Abs, Acos, Alias, And, Ascending, Ascii, Asin, Atan, AttributeReference, Base64, BitwiseAnd, BitwiseNot, BitwiseOr, BitwiseXor, CaseWhen, Cast, Coalesce, Concat, Contains, Cos, Cosh, DateAdd, DateSub, DenseRank, Descending, EndsWith, EqualNullSafe, EqualTo, Exp, ExprId, Floor, FormatNumber, FormatString, GreaterThan, GreaterThanOrEqual, Greatest, If, In, InSet, InitCap, IsNaN, IsNotNull, IsNull, Least, Length, LessThan, LessThanOrEqual, Literal, Log10, Logarithm, Lower, Month, Not, Or, PercentRank, Pi, Pow, PromotePrecision, Quarter, Rand, Rank, RegExpExtract, RegExpReplace, Round, RowNumber, ShiftLeft, ShiftRight, Signum, Sin, Sinh, SortOrder, SoundEx, Sqrt, StartsWith, StringInstr, StringLPad, StringRPad, StringTranslate, StringTrim, StringTrimLeft, StringTrimRight, Substring, Tan, Tanh, TruncDate, UnBase64, UnscaledValue, Upper, Year}
+import org.apache.spark.sql.catalyst.expressions.{Abs, Acos, AiqDayDiff, Alias, And, Ascending, Ascii, Asin, Atan, AttributeReference, Base64, BitwiseAnd, BitwiseNot, BitwiseOr, BitwiseXor, CaseWhen, Cast, Coalesce, Concat, Contains, Cos, Cosh, DateAdd, DateSub, DenseRank, Descending, EndsWith, EqualNullSafe, EqualTo, Exp, ExprId, Floor, FormatNumber, FormatString, GreaterThan, GreaterThanOrEqual, Greatest, If, In, InitCap, InSet, IsNaN, IsNotNull, IsNull, Least, Length, LessThan, LessThanOrEqual, Literal, Log10, Logarithm, Lower, Month, Not, Or, PercentRank, Pi, Pow, PromotePrecision, Quarter, Rand, Rank, RegExpExtract, RegExpReplace, Round, RowNumber, ShiftLeft, ShiftRight, Signum, Sin, Sinh, SortOrder, SoundEx, Sqrt, StartsWith, StringInstr, StringLPad, StringRPad, StringTranslate, StringTrim, StringTrimLeft, StringTrimRight, Substring, Tan, Tanh, TruncDate, UnBase64, UnscaledValue, Upper, Year}
 import org.apache.spark.sql.types._
 import org.mockito.{Mock, MockitoAnnotations}
 import org.scalatest.BeforeAndAfter
@@ -13,6 +13,7 @@ import org.scalatest.funsuite.AnyFunSuite
 class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
   private val schoolIdAttributeReference = AttributeReference.apply("SchoolID", LongType)(ExprId.apply(1))
   private val schoolStartDateAttributeReference = AttributeReference.apply("StartDate", DateType)(ExprId.apply(2))
+  private val startMsAttributeReference = AttributeReference("StartMs", LongType)(ExprId(3))
   private val fields = List(AttributeReference.apply("SchoolID", LongType)(ExprId.apply(1), List("SUBQUERY_2")))
   @Mock
   var directBigQueryRelationMock: DirectBigQueryRelation = _
@@ -941,6 +942,15 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
     val bigQuerySQLStatement = expressionConverter.convertDateExpressions(yearExpression, fields)
     assert(bigQuerySQLStatement.isDefined)
     assert(bigQuerySQLStatement.get.toString == "DATE_TRUNC ( '2016-07-30' , YEAR )")
+  }
+
+  test("convertDateExpressions with AiqDayDiff") {
+    val dayDiff = AiqDayDiff(startMsAttributeReference, Literal(1695945601000L), Literal("UTC"))
+    val bigQuerySQLStatement = expressionConverter.convertDateExpressions(dayDiff, fields)
+    assert(bigQuerySQLStatement.exists { s =>
+      s.toString == "DATE_DIFF ( DATE ( TIMESTAMP_MILLIS ( 1695945601000 ) , 'UTC' ) , " +
+        "DATE ( TIMESTAMP_MILLIS ( STARTMS ) , 'UTC' ) , DAY )"
+    })
   }
 
   test("convertWindowExpressions with RANK") {


### PR DESCRIPTION
Spark 3 for https://github.com/ActionIQ/spark-bigquery-connector/pull/9
Ran unit tests and integration tests

`./mvnw install -DskipTests`

Update the BQ connector version in flame, tested with flame in spark-shell:
```
com.google.cloud.spark.bigquery.BigQueryConnectorUtils.enablePushdownSession(spark)
val r1 = spark.read.format("bigquery").option("parentProject", "aiq-dev").option("credentialsFile", "/Users/dongyingzhou/Downloads/aiq-dev-e0ad53189782.json").option("materializationDataset", "connector_dev").option("dataset", "connector_dev").option("materializationExpirationTimeInMinutes", 60).option("viewsEnabled", true)

r1.load("aiq-dev.connector_dev.fct_transac_view").createOrReplaceTempView("f")

spark.sql("select channel from f where aiq_day_diff(transaction_at_ms, unix_timestamp() * 1000, 'America/New_York') > 10").queryExecution.sparkPlan
res8: org.apache.spark.sql.execution.SparkPlan =
Spark33BigQueryPushdownPlan [SUBQUERY_2_COL_0#74], PreScala213BigQueryRDD[0] at RDD at PreScala213BigQueryRDD.java:74, SELECT ( SUBQUERY_1.CHANNEL ) AS SUBQUERY_2_COL_0 FROM ( SELECT * FROM ( SELECT * FROM `aiq-dev.connector_dev.fct_transac_view` AS BQ_CONNECTOR_QUERY_ALIAS WHERE (`transaction_at_ms` IS NOT NULL) ) AS SUBQUERY_0 WHERE ( ( DATE_DIFF ( DATE ( TIMESTAMP_MILLIS ( 1696364680000 ) , 'America/New_York' ) , DATE ( TIMESTAMP_MILLIS ( SUBQUERY_0.TRANSACTION_AT_MS ) , 'America/New_York' ) , DAY ) > 10 ) AND ( SUBQUERY_0.TRANSACTION_AT_MS IS NOT NULL ) ) ) AS SUBQUERY_1

spark.sql("select channel from f where aiq_day_diff(transaction_at_ms, unix_timestamp() * 1000, 'America/New_York') > 10").count()
res9: Long = 243940502
```
