### PR TITLE
[EXE-2026] Select source table columns based on outputAttribute

### DIFF
--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
@@ -1111,6 +1111,23 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assert ((int) diff2.get(0).get(0) > 10); // 2023-09-01 to current
   }
 
+  @Test
+  /** AIQ EXE-2026 */
+  public void testSourceQuery() {
+    Dataset<Row> df = readTestDataFromBigQuery("connector_dev.basic");
+    df.createOrReplaceTempView("t");
+    Dataset<Row> df1 = spark.sql("select str_field from t limit 1");
+    Dataset<Row> df2 = spark.sql("select * from t limit 1");
+
+    List<Row> res1 = df1.collectAsList();
+    assertThat(res1.size()).isEqualTo(1);
+    assertThat(res1.get(0).size()).isEqualTo(1);
+
+    List<Row> res2 = df2.collectAsList();
+    assertThat(res2.size()).isEqualTo(1);
+    assertThat(res2.get(0).size()).isEqualTo(df.schema().size());
+  }
+
   /** Creating a Dataset of NumStructType which will be used to write to BigQuery */
   protected Dataset<Row> getNumStructDataFrame(List<NumStruct> numStructList) {
     return spark.createDataset(numStructList, Encoders.bean(NumStruct.class)).toDF();

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
@@ -30,6 +30,7 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import org.apache.spark.sql.execution.SparkPlan;
 import org.junit.Test;
 
 public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
@@ -332,7 +333,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
         testDataset.toString() + "." + testTable);
-    df = readTestDataFromBigQuery(testDataset.toString() + "." + testTable);
+    df = readTestDataFromBigQuery(testDataset.toString(), testDataset.toString() + "." + testTable);
     df.createOrReplaceTempView("numStructDF");
 
     result =
@@ -468,7 +469,8 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
         testDataset.toString() + "." + testTable);
-    Dataset<Row> df = readTestDataFromBigQuery(testDataset.toString() + "." + testTable);
+    Dataset<Row> df =
+        readTestDataFromBigQuery(testDataset.toString(), testDataset.toString() + "." + testTable);
     df.createOrReplaceTempView("numStructDF");
 
     List<Row> result =
@@ -511,7 +513,8 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
         getNumStructDataFrame(TestConstants.numStructDataset),
         testDataset.toString() + "." + testTable);
     // Creating a DataFrame of schema NumStruct, and writing it to BigQuery
-    Dataset<Row> df = readTestDataFromBigQuery(testDataset.toString() + "." + testTable);
+    Dataset<Row> df =
+        readTestDataFromBigQuery(testDataset.toString(), testDataset.toString() + "." + testTable);
 
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDatasetForJoin),
@@ -519,7 +522,8 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     // Creating an additional DataFrame of schema NumStruct, and writing it to BigQuery which will
     // be used for join
     Dataset<Row> df_to_join =
-        readTestDataFromBigQuery(testDataset.toString() + "." + testTable + "_to_join");
+        readTestDataFromBigQuery(
+            testDataset.toString(), testDataset.toString() + "." + testTable + "_to_join");
 
     // disabling pushdown to collect the join result to compare with pushdown enabled
     BigQueryConnectorUtils.disablePushdownSession(spark);
@@ -571,13 +575,15 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
         testDataset.toString() + "." + testTable);
-    Dataset<Row> df = readTestDataFromBigQuery(testDataset.toString() + "." + testTable);
+    Dataset<Row> df =
+        readTestDataFromBigQuery(testDataset.toString(), testDataset.toString() + "." + testTable);
 
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDatasetForJoin),
         testDataset.toString() + "." + testTable + "_to_join");
     Dataset<Row> df_to_join =
-        readTestDataFromBigQuery(testDataset.toString() + "." + testTable + "_to_join");
+        readTestDataFromBigQuery(
+            testDataset.toString(), testDataset.toString() + "." + testTable + "_to_join");
 
     // disabling pushdown to collect the join result to compare with pushdown enabled
     BigQueryConnectorUtils.disablePushdownSession(spark);
@@ -670,13 +676,15 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
         testDataset.toString() + "." + testTable);
-    Dataset<Row> df = readTestDataFromBigQuery(testDataset.toString() + "." + testTable);
+    Dataset<Row> df =
+        readTestDataFromBigQuery(testDataset.toString(), testDataset.toString() + "." + testTable);
 
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDatasetForJoin),
         testDataset.toString() + "." + testTable + "_to_join");
     Dataset<Row> df_to_join =
-        readTestDataFromBigQuery(testDataset.toString() + "." + testTable + "_to_join");
+        readTestDataFromBigQuery(
+            testDataset.toString(), testDataset.toString() + "." + testTable + "_to_join");
 
     // disabling pushdown to collect the join result to compare with pushdown enabled
     BigQueryConnectorUtils.disablePushdownSession(spark);
@@ -771,13 +779,15 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
         testDataset.toString() + "." + testTable);
-    Dataset<Row> df = readTestDataFromBigQuery(testDataset.toString() + "." + testTable);
+    Dataset<Row> df =
+        readTestDataFromBigQuery(testDataset.toString(), testDataset.toString() + "." + testTable);
 
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDatasetForJoin),
         testDataset.toString() + "." + testTable + "_to_join");
     Dataset<Row> df_to_join =
-        readTestDataFromBigQuery(testDataset.toString() + "." + testTable + "_to_join");
+        readTestDataFromBigQuery(
+            testDataset.toString(), testDataset.toString() + "." + testTable + "_to_join");
 
     // disabling pushdown to collect the join result to compare with pushdown enabled
     BigQueryConnectorUtils.disablePushdownSession(spark);
@@ -874,13 +884,15 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
         testDataset.toString() + "." + testTable);
-    Dataset<Row> df = readTestDataFromBigQuery(testDataset.toString() + "." + testTable);
+    Dataset<Row> df =
+        readTestDataFromBigQuery(testDataset.toString(), testDataset.toString() + "." + testTable);
 
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDatasetForJoin),
         testDataset.toString() + "." + testTable + "_to_join");
     Dataset<Row> df_to_join =
-        readTestDataFromBigQuery(testDataset.toString() + "." + testTable + "_to_join");
+        readTestDataFromBigQuery(
+            testDataset.toString(), testDataset.toString() + "." + testTable + "_to_join");
 
     // disabling pushdown to collect the join result to compare with pushdown enabled
     BigQueryConnectorUtils.disablePushdownSession(spark);
@@ -915,13 +927,15 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
         testDataset.toString() + "." + testTable);
-    Dataset<Row> df = readTestDataFromBigQuery(testDataset.toString() + "." + testTable);
+    Dataset<Row> df =
+        readTestDataFromBigQuery(testDataset.toString(), testDataset.toString() + "." + testTable);
 
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDatasetForJoin),
         testDataset.toString() + "." + testTable + "_to_join");
     Dataset<Row> df_to_join =
-        readTestDataFromBigQuery(testDataset.toString() + "." + testTable + "_to_join");
+        readTestDataFromBigQuery(
+            testDataset.toString(), testDataset.toString() + "." + testTable + "_to_join");
 
     // disabling pushdown to collect the join result to compare with pushdown enabled
     BigQueryConnectorUtils.disablePushdownSession(spark);
@@ -976,13 +990,15 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
         testDataset.toString() + "." + testTable);
-    Dataset<Row> df = readTestDataFromBigQuery(testDataset.toString() + "." + testTable);
+    Dataset<Row> df =
+        readTestDataFromBigQuery(testDataset.toString(), testDataset.toString() + "." + testTable);
 
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDatasetForJoin),
         testDataset.toString() + "." + testTable + "_to_join");
     Dataset<Row> df_to_join =
-        readTestDataFromBigQuery(testDataset.toString() + "." + testTable + "_to_join");
+        readTestDataFromBigQuery(
+            testDataset.toString(), testDataset.toString() + "." + testTable + "_to_join");
 
     // disabling pushdown to collect the join result to compare with pushdown enabled
     BigQueryConnectorUtils.disablePushdownSession(spark);
@@ -1030,14 +1046,16 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
         testDataset.toString() + "." + testTable);
-    Dataset<Row> df = readTestDataFromBigQuery(testDataset.toString() + "." + testTable);
+    Dataset<Row> df =
+        readTestDataFromBigQuery(testDataset.toString(), testDataset.toString() + "." + testTable);
     df.createOrReplaceTempView("numStructDF");
 
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDatasetForJoin),
         testDataset.toString() + "." + testTable + "_to_join");
     Dataset<Row> df_to_join =
-        readTestDataFromBigQuery(testDataset.toString() + "." + testTable + "_to_join");
+        readTestDataFromBigQuery(
+            testDataset.toString(), testDataset.toString() + "." + testTable + "_to_join");
     df_to_join.createOrReplaceTempView("numStructDF_to_join");
 
     String query =
@@ -1095,7 +1113,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
    * unix_millis(timestamp("2023-09-02T00:00:00")),"Asia/Shanghai");
    */
   public void testAiqDayDiff() {
-    Dataset<Row> df = readTestDataFromBigQuery("connector_dev.dt");
+    Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt");
     df.createOrReplaceTempView("dt");
     // INSERT might not follow the exact order
     List<Row> diffs1 =
@@ -1114,10 +1132,16 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
   @Test
   /** AIQ EXE-2026 */
   public void testSourceQuery() {
-    Dataset<Row> df = readTestDataFromBigQuery("connector_dev.basic");
+    Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.basic");
     df.createOrReplaceTempView("t");
     Dataset<Row> df1 = spark.sql("select str_field from t limit 1");
     Dataset<Row> df2 = spark.sql("select * from t limit 1");
+    SparkPlan sp1 = df1.queryExecution().sparkPlan();
+    SparkPlan sp2 = df2.queryExecution().sparkPlan();
+
+    assertThat(sp1.toString()).contains("SELECT STR_FIELD FROM `connector_dev.basic`");
+    // should select all columns instead *
+    assertThat(sp2.toString()).doesNotContain("SELECT * FROM `connector_dev.basic`");
 
     List<Row> res1 = df1.collectAsList();
     assertThat(res1.size()).isEqualTo(1);
@@ -1143,12 +1167,19 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
         .save();
   }
 
-  /** Method to read the test table of schema NumStruct, in test dataset */
-  protected Dataset<Row> readTestDataFromBigQuery(String table) {
+  /**
+   * Method to read the test table from a BigQuery dataset
+   *
+   * @param dataset: the dataset where the table is located
+   * @param table: in format of "dataset_name.table_name"
+   */
+  protected Dataset<Row> readTestDataFromBigQuery(String dataset, String table) {
     return spark
         .read()
         .format("bigquery")
-        .option("materializationDataset", testDataset.toString())
+        .option("materializationDataset", dataset)
+        .option("viewsEnabled", true)
+        .option("materializationExpirationTimeInMinutes", 30)
         .load(table);
   }
 }

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -85,7 +85,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq6</revision>
+        <revision>0.30.0-aiq7</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQuerySQLQuery.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQuerySQLQuery.scala
@@ -90,7 +90,7 @@ abstract class BigQuerySQLQuery(
     .map(p => renameColumns(p, alias, expressionFactory))
 
   /** Convert processedProjections into a BigQuerySQLStatement */
-  val columns: Option[BigQuerySQLStatement] =
+  def columns: Option[BigQuerySQLStatement] =
     processedProjections.map(
       p => makeStatement(p.map(expressionConverter.convertStatement(_, columnSet)), ",")
     )

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SourceQuery.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SourceQuery.scala
@@ -41,7 +41,7 @@ case class SourceQuery(
     }
 
     /** Builds the SELECT statement of the source query, if [[selectAttributes]] */
-    override val columns: Option[BigQuerySQLStatement] = {
+    override def columns: Option[BigQuerySQLStatement] = {
       if (selectAttributes) {
         Option(
           makeStatement(outputAttributes.map(expressionConverter.convertStatement(_, outputAttributes)), ",")

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SourceQuery.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SourceQuery.scala
@@ -46,7 +46,7 @@ case class SourceQuery(
         Option(
           makeStatement(outputAttributes.map(expressionConverter.convertStatement(_, outputAttributes)), ",")
         )
-      } else { None }
+      } else { super.columns }
     }
 
 }

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SourceQuerySuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SourceQuerySuite.scala
@@ -6,6 +6,7 @@ import org.scalatest.funsuite.AnyFunSuite
 class SourceQuerySuite extends AnyFunSuite{
 
   private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, bigQueryRDDFactoryMock, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
+  private val sourceQuery2 = SourceQuery(expressionConverter, expressionFactory, bigQueryRDDFactoryMock, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS, selectAttributes = true)
 
   test("sourceStatement") {
     assert(sourceQuery.sourceStatement.toString == "`test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS")
@@ -64,5 +65,10 @@ class SourceQuerySuite extends AnyFunSuite{
     val returnedQuery = sourceQuery.find({ case q: SourceQuery => q })
     assert(returnedQuery.isDefined)
     assert(returnedQuery.get == sourceQuery)
+  }
+
+  test("with projection") {
+    println(sourceQuery2.getStatement().toString)
+    assert(sourceQuery2.getStatement().toString == "SELECT SchoolID, SchoolName FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS")
   }
 }

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SourceQuerySuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SourceQuerySuite.scala
@@ -6,36 +6,46 @@ import org.scalatest.funsuite.AnyFunSuite
 class SourceQuerySuite extends AnyFunSuite{
 
   private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, bigQueryRDDFactoryMock, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
-  private val sourceQuery2 = SourceQuery(expressionConverter, expressionFactory, bigQueryRDDFactoryMock, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS, selectAttributes = true)
+  private val sourceQuery2 = sourceQuery.copy(selectAttributes = true)
 
   test("sourceStatement") {
     assert(sourceQuery.sourceStatement.toString == "`test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS")
+    assert(sourceQuery2.sourceStatement.toString == "`test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS")
   }
 
   test("suffixStatement") {
     assert(sourceQuery.suffixStatement.toString.isEmpty)
+    assert(sourceQuery2.suffixStatement.toString.isEmpty)
   }
 
   test("columnSet") {
     assert(sourceQuery.columnSet.isEmpty)
+    assert(sourceQuery2.columnSet.isEmpty)
   }
 
   test("processedProjections") {
     assert(sourceQuery.processedProjections.isEmpty)
+    assert(sourceQuery2.processedProjections.isEmpty)
   }
 
   test("columns") {
     assert(sourceQuery.columns.isEmpty)
+    assert(sourceQuery2.columns.exists(_.toString == "SCHOOLID , SCHOOLNAME"))
   }
 
   test("output") {
     assert(sourceQuery.output.size == 2)
     assert(sourceQuery.output == Seq(schoolIdAttributeReference, schoolNameAttributeReference))
+    assert(sourceQuery2.output.size == 2)
+    assert(sourceQuery2.output == Seq(schoolIdAttributeReference, schoolNameAttributeReference))
   }
 
   test("outputWithQualifier") {
     assert(sourceQuery.outputWithQualifier.size == 2)
     assert(sourceQuery.outputWithQualifier == Seq(schoolIdAttributeReference.withQualifier(Seq(SUBQUERY_0_ALIAS)),
+      schoolNameAttributeReference.withQualifier(Seq(SUBQUERY_0_ALIAS))))
+    assert(sourceQuery2.outputWithQualifier.size == 2)
+    assert(sourceQuery2.outputWithQualifier == Seq(schoolIdAttributeReference.withQualifier(Seq(SUBQUERY_0_ALIAS)),
       schoolNameAttributeReference.withQualifier(Seq(SUBQUERY_0_ALIAS))))
   }
 
@@ -44,31 +54,36 @@ class SourceQuerySuite extends AnyFunSuite{
     assert(nullableOutputWithQualifier.size == 2)
     assert(nullableOutputWithQualifier == Seq(schoolIdAttributeReference.withQualifier(Seq(SUBQUERY_0_ALIAS)).withNullability(true),
       schoolNameAttributeReference.withQualifier(Seq(SUBQUERY_0_ALIAS)).withNullability(true)))
+    val nullableOutputWithQualifier2 = sourceQuery2.nullableOutputWithQualifier
+    assert(nullableOutputWithQualifier2.size == 2)
+    assert(nullableOutputWithQualifier2 == Seq(schoolIdAttributeReference.withQualifier(Seq(SUBQUERY_0_ALIAS)).withNullability(true),
+      schoolNameAttributeReference.withQualifier(Seq(SUBQUERY_0_ALIAS)).withNullability(true)))
   }
 
   test("getStatement") {
     assert(sourceQuery.getStatement().toString == "SELECT * FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS")
+    assert(sourceQuery2.getStatement().toString == "SELECT SCHOOLID , SCHOOLNAME FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS")
   }
 
   test("getStatement with alias") {
     assert(sourceQuery.getStatement(useAlias = true).toString == "( SELECT * FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS ) AS SUBQUERY_0")
+    assert(sourceQuery2.getStatement(useAlias = true).toString == "( SELECT SCHOOLID , SCHOOLNAME FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS ) AS SUBQUERY_0")
   }
 
   test("getStatement with pushdownFilter set") {
     val sourceQueryWithPushdownFilter = SourceQuery(expressionConverter, expressionFactory, bigQueryRDDFactoryMock, TABLE_NAME,
       Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS, Option.apply("studentId = 1 AND studentName = Foo"))
+    val sourceQueryWithPushdownFilter2 = sourceQueryWithPushdownFilter.copy(selectAttributes = true)
     assert(sourceQueryWithPushdownFilter.getStatement().toString == "SELECT * FROM " +
+      "`test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS WHERE studentId = 1 AND studentName = Foo")
+    assert(sourceQueryWithPushdownFilter2.getStatement().toString == "SELECT SCHOOLID , SCHOOLNAME FROM " +
       "`test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS WHERE studentId = 1 AND studentName = Foo")
   }
 
   test("find") {
     val returnedQuery = sourceQuery.find({ case q: SourceQuery => q })
-    assert(returnedQuery.isDefined)
-    assert(returnedQuery.get == sourceQuery)
-  }
-
-  test("with projection") {
-    println(sourceQuery2.getStatement().toString)
-    assert(sourceQuery2.getStatement().toString == "SELECT SchoolID, SchoolName FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS")
+    assert(returnedQuery.exists(_ == sourceQuery))
+    val returnedQuery2 = sourceQuery2.find({ case q: SourceQuery => q })
+    assert(returnedQuery2.exists(_ == sourceQuery2))
   }
 }

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/UnionQuerySuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/UnionQuerySuite.scala
@@ -9,9 +9,15 @@ class UnionQuerySuite extends AnyFunSuite{
   private val sourceQuery2 = SourceQuery(expressionConverter, expressionFactory, bigQueryRDDFactoryMock, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_1_ALIAS)
 
   test(testName = "getStatement with nonempty children and useAlias true") {
-    val unionQuery = UnionQuery(expressionConverter, expressionFactory, Seq(sourceQuery1, sourceQuery2), SUBQUERY_2_ALIAS)
-    val bigQuerySQLStatement = unionQuery.getStatement(true)
-    assert(bigQuerySQLStatement.toString == "( ( SELECT * FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS ) UNION ALL ( SELECT * FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS ) ) AS SUBQUERY_2")
+    val unionQuery1 = UnionQuery(expressionConverter, expressionFactory, Seq(sourceQuery1, sourceQuery2), SUBQUERY_2_ALIAS)
+    val bigQuerySQLStatement1 = unionQuery1.getStatement(true)
+    println(bigQuerySQLStatement1)
+    assert(bigQuerySQLStatement1.toString == "( ( SELECT * FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS ) UNION ALL ( SELECT * FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS ) ) AS SUBQUERY_2")
+
+    val unionQuery2 = UnionQuery(expressionConverter, expressionFactory, Seq(sourceQuery1.copy(selectAttributes = true), sourceQuery2.copy(selectAttributes = true)), SUBQUERY_2_ALIAS)
+    val bigQuerySQLStatement2 = unionQuery2.getStatement(true)
+    println(bigQuerySQLStatement2)
+    assert(bigQuerySQLStatement2.toString == "( ( SELECT SCHOOLID , SCHOOLNAME FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS ) UNION ALL ( SELECT SCHOOLID , SCHOOLNAME FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS ) ) AS SUBQUERY_2")
   }
 
   test(testName = "getStatement with nonempty children and useAlias false") {

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/UnionQuerySuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/UnionQuerySuite.scala
@@ -11,12 +11,10 @@ class UnionQuerySuite extends AnyFunSuite{
   test(testName = "getStatement with nonempty children and useAlias true") {
     val unionQuery1 = UnionQuery(expressionConverter, expressionFactory, Seq(sourceQuery1, sourceQuery2), SUBQUERY_2_ALIAS)
     val bigQuerySQLStatement1 = unionQuery1.getStatement(true)
-    println(bigQuerySQLStatement1)
     assert(bigQuerySQLStatement1.toString == "( ( SELECT * FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS ) UNION ALL ( SELECT * FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS ) ) AS SUBQUERY_2")
 
     val unionQuery2 = UnionQuery(expressionConverter, expressionFactory, Seq(sourceQuery1.copy(selectAttributes = true), sourceQuery2.copy(selectAttributes = true)), SUBQUERY_2_ALIAS)
     val bigQuerySQLStatement2 = unionQuery2.getStatement(true)
-    println(bigQuerySQLStatement2)
     assert(bigQuerySQLStatement2.toString == "( ( SELECT SCHOOLID , SCHOOLNAME FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS ) UNION ALL ( SELECT SCHOOLID , SCHOOLNAME FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS ) ) AS SUBQUERY_2")
   }
 

--- a/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark33BigQueryStrategy.scala
+++ b/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark33BigQueryStrategy.scala
@@ -24,16 +24,17 @@ class Spark33BigQueryStrategy(expressionConverter: SparkExpressionConverter, exp
   override def generateQueryFromPlanForDataSourceV2(plan: LogicalPlan): Option[BigQuerySQLQuery] = {
     // DataSourceV2ScanRelation is the relation that is used in the Spark 3.3 DatasourceV2 connector
     plan match {
-      case scanRelation@DataSourceV2ScanRelation(_, _, _, _) =>
-        scanRelation.scan match {
+      case DataSourceV2ScanRelation(relation, scan, output, _) =>
+        scan match {
           case scan: SupportsQueryPushdown =>
             Some(SourceQuery(expressionConverter = expressionConverter,
               expressionFactory = expressionFactory,
               bigQueryRDDFactory = scan.getBigQueryRDDFactory,
-              tableName = SparkBigQueryUtil.getTableNameFromOptions(scanRelation.relation.options.asInstanceOf[java.util.Map[String, String]]),
-              outputAttributes = scanRelation.output,
+              tableName = SparkBigQueryUtil.getTableNameFromOptions(relation.options.asInstanceOf[java.util.Map[String, String]]),
+              outputAttributes = output,
               alias = alias.next,
-              pushdownFilters = if (scan.getPushdownFilters.isPresent) Some(scan.getPushdownFilters.get) else None
+              pushdownFilters = if (scan.getPushdownFilters.isPresent) Some(scan.getPushdownFilters.get) else None,
+              selectAttributes = true
             ))
 
           case _ => None


### PR DESCRIPTION
To address the issue detailed in [this comment](https://actioniq.atlassian.net/browse/EXE-2026?focusedCommentId=124983)

Adding a `selectAttributes` flag to `SourceQuery`, when set `true`, generate the BigQuery query such that its SELECT clause contains columns specified in `outputAttributes`, to make sure that the returned data from BigQuery contains the same columns as outputAttributes does. 
I didn't use `BigQuerySQLQuery.projections` because it adds aliases to the columns, but we want the columns to be selected as their original name to maintain the existing behavior. Updating `columns` value seems to have the least impact, since it's only used in building the final SELECT statement

Tested in flame:
```
val qe = spark.sql("select customer_id, first_name from f limit 10").queryExecution

scala> qe.optimizedPlan
res7: org.apache.spark.sql.catalyst.plans.logical.LogicalPlan =
GlobalLimit 10
+- LocalLimit 10
   +- RelationV2[customer_id#0L, first_name#13] dim_customer

scala> qe.sparkPlan
res8: org.apache.spark.sql.execution.SparkPlan =
Spark33BigQueryPushdownPlan [customer_id#0L, first_name#13], PreScala213BigQueryRDD[0] at RDD at PreScala213BigQueryRDD.java:77, SELECT * FROM ( SELECT CUSTOMER_ID , FIRST_NAME FROM `aiq-dev.connector_dev.dim_customer` AS BQ_CONNECTOR_QUERY_ALIAS ) AS SUBQUERY_0 LIMIT 10
```
Before this change, `qe.sparkPlan` would be
```
Spark33BigQueryPushdownPlan [customer_id#0L, first_name#13], PreScala213BigQueryRDD[0] at RDD at PreScala213BigQueryRDD.java:77, SELECT * FROM ( SELECT * FROM `aiq-dev.connector_dev.dim_customer` AS BQ_CONNECTOR_QUERY_ALIAS ) AS SUBQUERY_0 LIMIT 10
```
whose `PreScala213BigQueryRDD`'s schema doesn't match outputAttributes `[customer_id#0L, first_name#13]` and breaks downstream computations

Adding unit tests and integration tests, also fixing an issue with integration test: the source data should be in `materializationDataset` otherwise query pushdown will fail 

Ran unit tests and integration tests
