### PR TITLE
[EXE-2032][EXE-2055][SPARK3] Pushdown for approx_count_distinct + default pushdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1313,13 +1313,13 @@ Run all tests except acceptance test and integration tests
 # Integration Tests
 To run integration test with `aiq-dev` BigQuery instance, download the service account credentials to a local
 file, then run
-```bash
+```
 export GOOGLE_APPLICATION_CREDENTIALS=<path_to_the_file>
 export GOOGLE_CLOUD_PROJECT=aiq-dev
 ```
 
 Run integration tests:
-```bash
+```
 # make sure to do this after updating tests - for some reason failsafe:integration-test doesn't compile tests before running
 ./mvnw install -Pintegration -DskipTests
 

--- a/README.md
+++ b/README.md
@@ -1301,7 +1301,7 @@ Bump `revision` in `spark-bigquery-parent/pom.xml` to the next `-aiq#` version
 # Build
 This places artifacts in `~/.m2/repository/`
 ```
-./mvnw clean install
+./mvnw clean install -DskipTests
 ```
 
 # Unit Tests

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -94,6 +94,7 @@ public class SparkBigQueryConfig
     }
   }
 
+  public static final String PUSHDOWN_ENABLED = "pushdownEnabled";
   public static final String VIEWS_ENABLED_OPTION = "viewsEnabled";
   public static final String USE_AVRO_LOGICAL_TYPES_OPTION = "useAvroLogicalTypes";
   public static final String DATE_PARTITION_PARAM = "datePartition";

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
@@ -37,6 +37,19 @@ import org.junit.Test;
 public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
 
   @Test
+  /** EXE-2055 */
+  public void testApproxCountDistinct() {
+    Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt");
+    df.createOrReplaceTempView("dt");
+    List<Row> results =
+        spark
+            .sql("select approx_count_distinct(id), approx_count_distinct(ts1) from dt")
+            .collectAsList();
+    assert (results.get(0).getLong(0) == 3);
+    assert (results.get(0).getLong(1) == 1);
+  }
+
+  @Test
   public void testStringFunctionExpressions() {
     Dataset<Row> df =
         spark

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
 
   @Test
-  /** EXE-2055 */
   public void testApproxCountDistinct() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt");
     df.createOrReplaceTempView("dt");

--- a/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
+++ b/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
@@ -71,6 +71,10 @@ class BigQueryRelationProvider(
                                         sqlContext: SQLContext,
                                         parameters: Map[String, String],
                                         schema: Option[StructType] = None): BigQueryRelation = {
+    val pushdownEnabled = parameters.getOrElse(SparkBigQueryConfig.PUSHDOWN_ENABLED, "true").toBoolean
+    if (pushdownEnabled) {
+      BigQueryConnectorUtils.enablePushdownSession(sqlContext.sparkSession)
+    }
     val injector = getGuiceInjectorCreator().createGuiceInjector(sqlContext, parameters, schema)
     val opts = injector.getInstance(classOf[SparkBigQueryConfig])
     val bigQueryClient = injector.getInstance(classOf[BigQueryClient])

--- a/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
+++ b/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
@@ -71,10 +71,6 @@ class BigQueryRelationProvider(
                                         sqlContext: SQLContext,
                                         parameters: Map[String, String],
                                         schema: Option[StructType] = None): BigQueryRelation = {
-    val pushdownEnabled = parameters.getOrElse(SparkBigQueryConfig.PUSHDOWN_ENABLED, "true").toBoolean
-    if (pushdownEnabled) {
-      BigQueryConnectorUtils.enablePushdownSession(sqlContext.sparkSession)
-    }
     val injector = getGuiceInjectorCreator().createGuiceInjector(sqlContext, parameters, schema)
     val opts = injector.getInstance(classOf[SparkBigQueryConfig])
     val bigQueryClient = injector.getInstance(classOf[BigQueryClient])

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -85,7 +85,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq8</revision>
+        <revision>0.30.0-aiq10</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -85,7 +85,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq7</revision>
+        <revision>0.30.0-aiq8</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>
@@ -126,7 +126,7 @@
         <!-- checkstyle
         <checkstyle.header.file>${reactor.project.basedir}/java.header</checkstyle.header.file>
         -->
-        <spark.version>3-3-2-aiq35</spark.version>
+        <spark.version>3-3-2-aiq40</spark.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.patch.version>15</scala.patch.version>
     </properties>

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
@@ -41,6 +41,12 @@ abstract class SparkExpressionConverter {
         // Take only the first child, as all of the functions below have only one.
         expression.children.headOption.flatMap(agg_fun => {
           Option(agg_fun match {
+            case _: HyperLogLogPlusPlus =>
+              // NOTE: We are not passing through the other parameters in Spark's HLL
+              // like mutableAggBufferOffset and inputAggBufferOffset
+              ConstantString("APPROX_COUNT_DISTINCT") +
+                blockStatement(convertStatements(fields, agg_fun.children: _*))
+
             case _: Average | _: Corr | _: CovPopulation | _: CovSample | _: Count |
                  _: Max | _: Min | _: Sum | _: StddevPop | _: StddevSamp |
                  _: VariancePop | _: VarianceSamp =>


### PR DESCRIPTION
Adding pushdown for `approx_count_distinct` (which internally is called HyperLogLog HLL). Note the one in Spark has some [extra values here](https://github.com/ActionIQ/flame/blob/0945baf90660a101ae0f86a39d4c91ca74ae5ee3/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/HyperLogLogPlusPlus.scala#L59-L64), I'm not passing those through. I *think* its ok because it still ends up doing the same basic function.

I also made pushdown the default behavior, so that means we dont have to compile the bigquery lib in AIQ code (similar to how snowflake works, pushdown is default). But you can pass `df.read.option("pushdownEnabled", "false")` to not have it. 

### Test Notes
```
export GOOGLE_APPLICATION_CREDENTIALS=/Users/mitesh/Downloads/aiq-dev-208e4d81b9a1.json
export GOOGLE_CLOUD_PROJECT=aiq-dev

./mvnw failsafe:integration-test -fn \
  -Dfailsafe.failIfNoSpecifiedTests=false \
  -Dit.test=com.google.cloud.spark.bigquery.integration.Spark33QueryPushdownIntegrationTest
```

Test should pass and see pushed down query like this:
> 23/10/25 23:19:49 INFO BigQueryRDDFactory: Materializing the following sql query to a BigQuery table: SELECT ( APPROX_COUNT_DISTINCT ( SUBQUERY_12.ID ) ) AS SUBQUERY_13_COL_0 , ( APPROX_COUNT_DISTINCT ( SUBQUERY_12.TS1 ) ) AS SUBQUERY_13_COL_1 FROM ( SELECT ID , TS1 FROM `connector_dev.dt` AS BQ_CONNECTOR_QUERY_ALIAS ) AS SUBQUERY_12 LIMIT 1

Also run the other tests mentioned in README
### Deploy Notes
`./mvnw deploy`