### PR TITLE
[DP-98] Add aiq_date_to_string pushdown

### DIFF
--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.java
@@ -123,7 +123,7 @@ public class DirectBigQueryRelation extends BigQueryRelation
           .sparkContext()
           .dataSourceTelemetry()
           .numOfFailedPushDownQueries()
-          .getAndDecrement();
+          .getAndIncrement();
     }
 
     log.info(

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
@@ -34,11 +34,12 @@ import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.types.DataTypes;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
 
-  @Test
+  @Ignore
   public void testApproxCountDistinct() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt");
     df.createOrReplaceTempView("dt");
@@ -50,7 +51,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assert (results.get(0).getLong(1) == 1);
   }
 
-  @Test
+  @Ignore
   public void testStringFunctionExpressions() {
     Dataset<Row> df =
         spark
@@ -112,7 +113,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(22)).isEqualTo(false); // LIKE(word, 'b_g_rs')
   }
 
-  @Test
+  @Ignore
   public void testDateFunctionExpressions() {
     // This table only has one row and one column which is today's date
     Dataset<Row> df =
@@ -152,7 +153,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(6).toString()).isEqualTo(date.with(firstDayOfYear()).toString()); // TRUNC
   }
 
-  @Test
+  @Ignore
   public void testBasicExpressions() {
     Dataset<Row> df =
         spark
@@ -185,7 +186,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(4)).isEqualTo(false); // 'augurs' <=> 'sonnets'
   }
 
-  @Test
+  @Ignore
   public void testMathematicalFunctionExpressions() {
     Dataset<Row> df =
         spark
@@ -245,7 +246,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(22)).isEqualTo(1.0); // SIGNUM(word_count)
   }
 
-  @Test
+  @Ignore
   public void testMiscellaneousExpressions() {
     Dataset<Row> df =
         spark
@@ -287,7 +288,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(11)).isEqualTo(false); // CHECKOVERFLOW
   }
 
-  @Test
+  @Ignore
   public void testUnionQuery() {
     Dataset<Row> df =
         spark
@@ -316,7 +317,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(unionByNameList.get(0).get(1)).isAnyOf(100L, 150L);
   }
 
-  @Test
+  @Ignore
   public void testBooleanExpressions() {
     Dataset<Row> df =
         spark
@@ -378,7 +379,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(8)).isEqualTo(true); // In
   }
 
-  @Test
+  @Ignore
   public void testWindowStatements() {
     Dataset<Row> df =
         spark
@@ -427,7 +428,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(row.get(10)).isEqualTo(3677); // COUNT(word) OVER count_window
   }
 
-  @Test
+  @Ignore
   public void testWindowQueryWithWindowSpec() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -479,7 +480,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r.get(2)).isEqualTo(4);
   }
 
-  @Test
+  @Ignore
   public void testAggregateExpressions() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -522,7 +523,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(11)).isEqualTo(0.5); // VAR_SAMP(num1)
   }
 
-  @Test
+  @Ignore
   public void testInnerJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -585,7 +586,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Test
+  @Ignore
   public void testLeftOuterJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -686,7 +687,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Test
+  @Ignore
   public void testRightOuterJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -789,7 +790,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Test
+  @Ignore
   public void testFullOuterJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -894,7 +895,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Test
+  @Ignore
   public void testCrossJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -937,7 +938,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(df_to_join.crossJoin(df).collectAsList().size()).isEqualTo(6);
   }
 
-  @Test
+  @Ignore
   public void testLeftSemiJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -1000,7 +1001,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Test
+  @Ignore
   public void testLeftAntiJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -1056,7 +1057,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(result.get(0).get(0)).isEqualTo(6);
   }
 
-  @Test
+  @Ignore
   public void testJoinQuery() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -1115,7 +1116,6 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  // spotless:off
   /**
    * Reading from a BigQuery table created with: create or replace table aiq-dev.connector_dev.dt (
    * id integer, ts1 integer, ts2 integer, tz string );
@@ -1127,8 +1127,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
    * unix_millis(timestamp("2023-09-01T23:59:59")),
    * unix_millis(timestamp("2023-09-02T00:00:00")),"Asia/Shanghai");
    */
-  // spotless:on
-  @Test
+  @Ignore
   public void testAiqDayDiff() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt");
     df.createOrReplaceTempView("dt");
@@ -1146,7 +1145,6 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assert ((int) diff2.get(0).get(0) > 10); // 2023-09-01 to current
   }
 
-  // spotless:off
   /**
    * Reading from a BigQuery table created with: create or replace table aiq-dev.connector_dev.dt2 (
    * ts int64, fmt string, tz string );
@@ -1159,7 +1157,6 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
    * (1567363852000, 'yyyy-MM-dd hh:mm:ss', 'America/New_York'), (1567363852000, 'yyyy-MM-dd
    * hh:mm:mm:ss', 'America/New_York')
    */
-  // spotless:on
   @Test
   public void testAiqDateToString() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt2");
@@ -1183,8 +1180,8 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
             "2019-09-01 02:50:50:52"));
   }
 
-  @Test
-  /** AIQ EXE-2026 */
+  /** Test for AIQ EXE-2026 */
+  @Ignore
   public void testSourceQuery() {
     spark
         .sqlContext()

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
@@ -1146,29 +1146,31 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
   }
 
   /**
-   * Reading from a BigQuery table created with: create or replace table aiq-dev.connector_dev.dt2 (
-   * ts int64, fmt string, tz string );
+   * Reading from a BigQuery table created with: create or replace table aiq-dev.connector_dev.dt2
+   * (id integer, ts int64, fmt string, tz string );
    *
-   * <p>insert into aiq-dev.connector_dev.dt2 values (1567363852000, 'MM', 'America/New_York'),
-   * (1567363852000, 'yyyy-MM-dd', 'America/New_York'), (1567363852000, 'yyyy-MM-dd HH:mm',
-   * 'America/New_York'), (1567363852000, 'yyyy-MM-dd hh:mm a', 'America/New_York'), (1567363852000,
-   * 'yyyy-MM-dd a hh:mm', 'America/New_York'), (1567363852000, 'yyyy-MM-dd a hh:mm:mm:ss a',
-   * 'America/New_York'), (1567363852000, 'yyyy-MM-dd HH:mm:ss', 'America/New_York'),
-   * (1567363852000, 'yyyy-MM-dd hh:mm:ss', 'America/New_York'), (1567363852000, 'yyyy-MM-dd
-   * hh:mm:mm:ss', 'America/New_York')
+   * <p>insert into aiq-dev.connector_dev.dt2 values (0, 1567363852000, 'MM', 'America/New_York'),
+   * (1, 1567363852000, 'yyyy-MM-dd', 'America/New_York'), (2, 1567363852000, 'yyyy-MM-dd HH:mm',
+   * 'America/New_York'), (3, 1567363852000, 'yyyy-MM-dd hh:mm a', 'America/New_York'), (4,
+   * 1567363852000, 'yyyy-MM-dd a hh:mm', 'America/New_York'), (5, 1567363852000, 'yyyy-MM-dd a
+   * hh:mm:mm:ss a', 'America/New_York'), (6, 1567363852000, 'yyyy-MM-dd HH:mm:ss',
+   * 'America/New_York'), (7, 1567363852000, 'yyyy-MM-dd hh:mm:ss', 'America/New_York'), (8,
+   * 1567363852000, 'yyyy-MM-dd hh:mm:mm:ss', 'America/New_York')
    */
   @Test
   public void testAiqDateToString() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt2");
     df.createOrReplaceTempView("dt2");
     List<String> results =
-        spark.sql("select aiq_date_to_string(ts, fmt, tz) as res from dt2 order by res")
-            .collectAsList().stream()
+        spark.sql("select aiq_date_to_string(ts, fmt, tz) from dt2 order by id").collectAsList()
+            .stream()
             .map(r -> r.getString(0))
             .collect(Collectors.toList());
 
-    assert (results
-        == Arrays.asList(
+    System.out.println("Results" + results);
+
+    assert (results.equals(
+        Arrays.asList(
             "09",
             "2019-09-01",
             "2019-09-01 14:50",
@@ -1177,7 +1179,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
             "2019-09-01 PM 02:50:50:52 PM",
             "2019-09-01 14:50:52",
             "2019-09-01 02:50:52",
-            "2019-09-01 02:50:50:52"));
+            "2019-09-01 02:50:50:52")));
   }
 
   /** Test for AIQ EXE-2026 */

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
@@ -18,6 +18,7 @@ package com.google.cloud.spark.bigquery.integration;
 import static com.google.common.truth.Truth.assertThat;
 import static java.time.temporal.TemporalAdjusters.firstDayOfYear;
 
+import com.google.cloud.Tuple;
 import com.google.cloud.spark.bigquery.BigQueryConnectorUtils;
 import com.google.cloud.spark.bigquery.SparkBigQueryConfig.WriteMethod;
 import com.google.cloud.spark.bigquery.integration.model.NumStruct;
@@ -26,6 +27,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.IsoFields;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
@@ -34,12 +36,18 @@ import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.types.DataTypes;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
 
-  @Ignore
+  private static <T> List<Tuple<Integer, T>> zipWithIndex(List<T> items) {
+    AtomicInteger counter = new AtomicInteger();
+    return items.stream()
+        .map(element -> Tuple.of(counter.getAndIncrement(), element))
+        .collect(Collectors.toList());
+  }
+
+  @Test
   public void testApproxCountDistinct() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt");
     df.createOrReplaceTempView("dt");
@@ -51,7 +59,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assert (results.get(0).getLong(1) == 1);
   }
 
-  @Ignore
+  @Test
   public void testStringFunctionExpressions() {
     Dataset<Row> df =
         spark
@@ -113,7 +121,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(22)).isEqualTo(false); // LIKE(word, 'b_g_rs')
   }
 
-  @Ignore
+  @Test
   public void testDateFunctionExpressions() {
     // This table only has one row and one column which is today's date
     Dataset<Row> df =
@@ -153,7 +161,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(6).toString()).isEqualTo(date.with(firstDayOfYear()).toString()); // TRUNC
   }
 
-  @Ignore
+  @Test
   public void testBasicExpressions() {
     Dataset<Row> df =
         spark
@@ -186,7 +194,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(4)).isEqualTo(false); // 'augurs' <=> 'sonnets'
   }
 
-  @Ignore
+  @Test
   public void testMathematicalFunctionExpressions() {
     Dataset<Row> df =
         spark
@@ -246,7 +254,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(22)).isEqualTo(1.0); // SIGNUM(word_count)
   }
 
-  @Ignore
+  @Test
   public void testMiscellaneousExpressions() {
     Dataset<Row> df =
         spark
@@ -288,7 +296,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(11)).isEqualTo(false); // CHECKOVERFLOW
   }
 
-  @Ignore
+  @Test
   public void testUnionQuery() {
     Dataset<Row> df =
         spark
@@ -317,7 +325,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(unionByNameList.get(0).get(1)).isAnyOf(100L, 150L);
   }
 
-  @Ignore
+  @Test
   public void testBooleanExpressions() {
     Dataset<Row> df =
         spark
@@ -379,7 +387,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(8)).isEqualTo(true); // In
   }
 
-  @Ignore
+  @Test
   public void testWindowStatements() {
     Dataset<Row> df =
         spark
@@ -428,7 +436,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(row.get(10)).isEqualTo(3677); // COUNT(word) OVER count_window
   }
 
-  @Ignore
+  @Test
   public void testWindowQueryWithWindowSpec() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -480,7 +488,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r.get(2)).isEqualTo(4);
   }
 
-  @Ignore
+  @Test
   public void testAggregateExpressions() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -523,7 +531,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(11)).isEqualTo(0.5); // VAR_SAMP(num1)
   }
 
-  @Ignore
+  @Test
   public void testInnerJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -586,7 +594,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Ignore
+  @Test
   public void testLeftOuterJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -687,7 +695,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Ignore
+  @Test
   public void testRightOuterJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -790,7 +798,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Ignore
+  @Test
   public void testFullOuterJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -895,7 +903,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Ignore
+  @Test
   public void testCrossJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -938,7 +946,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(df_to_join.crossJoin(df).collectAsList().size()).isEqualTo(6);
   }
 
-  @Ignore
+  @Test
   public void testLeftSemiJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -1001,7 +1009,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Ignore
+  @Test
   public void testLeftAntiJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -1057,7 +1065,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(result.get(0).get(0)).isEqualTo(6);
   }
 
-  @Ignore
+  @Test
   public void testJoinQuery() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -1117,21 +1125,23 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
   }
 
   /**
-   * Reading from a BigQuery table created with: create or replace table aiq-dev.connector_dev.dt (
-   * id integer, ts1 integer, ts2 integer, tz string );
+   * Reading from a BigQuery table created with (note selects will not keep the order, so sort by
+   * id):
    *
-   * <p>insert `aiq-dev.connector_dev.dt` values (0, unix_millis(timestamp("2023-09-01T23:59:59")),
+   * <p>create or replace table aiq-dev.connector_dev.dt (id integer, ts1 integer, ts2 integer, tz
+   * string );
+   *
+   * <p>insert aiq-dev.connector_dev.dt values (0, unix_millis(timestamp("2023-09-01T23:59:59")),
    * unix_millis(timestamp("2023-09-02T00:00:00")),"UTC"), (1,
    * unix_millis(timestamp("2023-09-01T23:59:59")),
    * unix_millis(timestamp("2023-09-02T00:00:00")),"America/New_York"), (2,
    * unix_millis(timestamp("2023-09-01T23:59:59")),
    * unix_millis(timestamp("2023-09-02T00:00:00")),"Asia/Shanghai");
    */
-  @Ignore
+  @Test
   public void testAiqDayDiff() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt");
     df.createOrReplaceTempView("dt");
-    // INSERT might not follow the exact order
     List<Row> diffs1 =
         spark.sql("select aiq_day_diff(ts1, ts2, tz) from dt order by id").collectAsList();
     assertThat(diffs1.size()).isEqualTo(3);
@@ -1146,8 +1156,91 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
   }
 
   /**
-   * Reading from a BigQuery table created with: create or replace table aiq-dev.connector_dev.dt2
-   * (id integer, ts int64, fmt string, tz string );
+   * Reading from a BigQuery table created with:
+   *
+   * <p>create or replace table aiq-dev.connector_dev.dt3 (ts integer )
+   *
+   * <p>insert into aiq-dev.connector_dev.dt3 values (1567363852000)
+   */
+  @Test
+  public void testAiqDateToStringPart1() {
+    var df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt3");
+    df.createOrReplaceTempView("dt3");
+
+    var formatTestsWithIndex =
+        zipWithIndex(
+            Arrays.asList(
+                "MM",
+                "yyyy-MM-dd",
+                "yyyy-MM-dd HH:mm",
+                "yyyy-MM-dd hh:mm a",
+                "yyyy-MM-dd a hh:mm",
+                "yyyy-MM-dd a hh:mm:mm:ss a",
+                "yyyy-MM-dd HH:mm:ss",
+                "yyyy-MM-dd hh:mm:ss",
+                "yyyy-MM-dd hh:mm:mm:ss",
+                "yyyy-MM-dd M HH:mm:ss",
+                "yyyy-MM-dd MM HH:mm:ss",
+                "yyyy-MM-dd aMa HH:mm:ss",
+                "yyyy-MM-dd MMM HH:mm:ss",
+                "yyyy-MM-dd aMMMa HH:mm:ss",
+                "yyyy-MM-dd MMMM HH:mm:ss",
+                "yyyy-MM-dd MMMMM HH:mm:ss",
+                "yyyy-MM-dd MMMMMM HH:mm:ss",
+                "yyyy-MM-dd E HH:mm:ss",
+                "yyyy-MM-dd EE HH:mm:ss",
+                "yyyy-MM-dd EEE HH:mm:ss",
+                "yyyy-MM-dd EEEE HH:mm:ss",
+                "yyyy-MM-dd EEEEEEEE HH:mm:ss"));
+
+    var sqlSelects =
+        formatTestsWithIndex.stream()
+            .map(
+                f ->
+                    "select "
+                        + f.x()
+                        + " as id, aiq_date_to_string(ts, '"
+                        + f.y()
+                        + "', 'America/New_York') as res from dt3")
+            .collect(Collectors.toList());
+
+    List<String> results =
+        spark.sql(String.join(" UNION ALL ", sqlSelects) + " ORDER BY id").collectAsList().stream()
+            .map(r -> r.getString(1))
+            .collect(Collectors.toList());
+
+    assert (results.equals(
+        Arrays.asList(
+            "09",
+            "2019-09-01",
+            "2019-09-01 14:50",
+            "2019-09-01 02:50 PM",
+            "2019-09-01 PM 02:50",
+            "2019-09-01 PM 02:50:50:52 PM",
+            "2019-09-01 14:50:52",
+            "2019-09-01 02:50:52",
+            "2019-09-01 02:50:50:52",
+            "2019-09-01 09 14:50:52",
+            "2019-09-01 09 14:50:52",
+            "2019-09-01 PM09PM 14:50:52",
+            "2019-09-01 Sep 14:50:52",
+            "2019-09-01 PMSepPM 14:50:52",
+            "2019-09-01 September 14:50:52",
+            "2019-09-01 September 14:50:52",
+            "2019-09-01 September 14:50:52",
+            "2019-09-01 Sun 14:50:52",
+            "2019-09-01 Sun 14:50:52",
+            "2019-09-01 Sun 14:50:52",
+            "2019-09-01 Sunday 14:50:52",
+            "2019-09-01 Sunday 14:50:52")));
+  }
+
+  /**
+   * Reading from a BigQuery table created with (note selects will not keep the order, so sort by
+   * id):
+   *
+   * <p>create or replace table aiq-dev.connector_dev.dt2 (id integer, ts int64, fmt string, tz
+   * string );
    *
    * <p>insert into aiq-dev.connector_dev.dt2 values (0, 1567363852000, 'MM', 'America/New_York'),
    * (1, 1567363852000, 'yyyy-MM-dd', 'America/New_York'), (2, 1567363852000, 'yyyy-MM-dd HH:mm',
@@ -1158,16 +1251,15 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
    * 1567363852000, 'yyyy-MM-dd hh:mm:mm:ss', 'America/New_York')
    */
   @Test
-  public void testAiqDateToString() {
+  public void testAiqDateToStringPart2() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt2");
     df.createOrReplaceTempView("dt2");
+
     List<String> results =
         spark.sql("select aiq_date_to_string(ts, fmt, tz) from dt2 order by id").collectAsList()
             .stream()
             .map(r -> r.getString(0))
             .collect(Collectors.toList());
-
-    System.out.println("Results" + results);
 
     assert (results.equals(
         Arrays.asList(
@@ -1183,7 +1275,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
   }
 
   /** Test for AIQ EXE-2026 */
-  @Ignore
+  @Test
   public void testSourceQuery() {
     spark
         .sqlContext()

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
@@ -36,6 +36,7 @@ import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.types.DataTypes;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
@@ -387,7 +388,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(8)).isEqualTo(true); // In
   }
 
-  @Test
+  @Ignore("TODO: give this more memory")
   public void testWindowStatements() {
     Dataset<Row> df =
         spark

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -85,7 +85,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq15</revision>
+        <revision>0.30.0-aiq16</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>
@@ -126,7 +126,7 @@
         <!-- checkstyle
         <checkstyle.header.file>${reactor.project.basedir}/java.header</checkstyle.header.file>
         -->
-        <spark.version>3-3-2-aiq99</spark.version>
+        <spark.version>3-3-2-aiq110</spark.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.patch.version>15</scala.patch.version>
     </properties>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -128,7 +128,7 @@
         <!-- checkstyle
         <checkstyle.header.file>${reactor.project.basedir}/java.header</checkstyle.header.file>
         -->
-        <spark.version>3-3-2-aiq110</spark.version>
+        <spark.version>3-3-2-aiq109</spark.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.patch.version>15</scala.patch.version>
     </properties>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -106,7 +106,9 @@
         <nexus.remote.skip>false</nexus.remote.skip>
         <shade.skip>true</shade.skip>
         <argLine>
+            <!-- TODO: figure out how to give tests more memory, then enable testWindowStatements -->
             <!-- https://github.com/ActionIQ/flame/blob/3.3/pom.xml#L309C1-L323C48 -->
+            -XX:+IgnoreUnrecognizedVMOptions
             --add-opens=java.base/java.lang=ALL-UNNAMED
             --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
             --add-opens=java.base/java.lang.reflect=ALL-UNNAMED

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
@@ -252,7 +252,7 @@ abstract class SparkExpressionConverter {
         val tsMillisStmt = ConstantString("TIMESTAMP_MILLIS") + blockStatement(convertStatement(timestamp, fields))
         val datetimeStmt = ConstantString("DATETIME") + blockStatement(tsMillisStmt + "," + convertStatement(timezoneId, fields))
         val fixedFormat = isoDateFmtToBigQuery(dateFormat.toString)
-        val formatStr = s""" AS STRING FORMAT "$fixedFormat""""
+        val formatStr = s"""AS STRING FORMAT "$fixedFormat""""
         ConstantString("CAST") + blockStatement(datetimeStmt + formatStr)
 
       case _ => null

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
@@ -947,18 +947,17 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
   test("convertDateExpressions with AiqDayDiff") {
     val exp = AiqDayDiff(startMsAttributeReference, Literal(1695945601000L), Literal("UTC"))
     val bigQuerySQLStatement = expressionConverter.convertDateExpressions(exp, fields)
-    assert(bigQuerySQLStatement.exists { s =>
-      s.toString == "DATE_DIFF ( DATE ( TIMESTAMP_MILLIS ( 1695945601000 ) , 'UTC' ) , " +
+    assert(bigQuerySQLStatement.get.toString == "DATE_DIFF ( DATE ( TIMESTAMP_MILLIS ( 1695945601000 ) , 'UTC' ) , " +
         "DATE ( TIMESTAMP_MILLIS ( STARTMS ) , 'UTC' ) , DAY )"
-    })
+    )
   }
 
   test("convertDateExpressions with AiqDateToString") {
     val exp = AiqDateToString(startMsAttributeReference, Literal("yyyy-MM-dd HH:mm"), Literal("America/New_York"))
     val bigQuerySQLStatement = expressionConverter.convertDateExpressions(exp, fields)
-    assert(bigQuerySQLStatement.exists { s =>
-      s.toString == "CAST ( DATETIME ( TIMESTAMP_MILLIS ( STARTMS ) , 'America/New_York' ) AS STRING FORMAT \"yyyy-MM-dd HH24:MI\""
-    })
+    assert(
+      bigQuerySQLStatement.get.toString == "CAST ( DATETIME ( TIMESTAMP_MILLIS ( STARTMS ) , 'America/New_York' ) AS STRING FORMAT \"yyyy-MM-dd HH24:MI\" )"
+    )
   }
 
   test("convertWindowExpressions with RANK") {

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
@@ -957,7 +957,7 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
     val exp = AiqDateToString(startMsAttributeReference, Literal("yyyy-MM-dd HH:mm"), Literal("America/New_York"))
     val bigQuerySQLStatement = expressionConverter.convertDateExpressions(exp, fields)
     assert(bigQuerySQLStatement.exists { s =>
-      s.toString == "CAST ( DATETIME ( TIMESTAMP_MILLIS ( STARTMS ) , 'America/New_York' ) AS STRING FORMAT \"yyyy-MM-dd HH24:mi\""
+      s.toString == "CAST ( DATETIME ( TIMESTAMP_MILLIS ( STARTMS ) , 'America/New_York' ) AS STRING FORMAT \"yyyy-MM-dd HH24:MI\""
     })
   }
 

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
@@ -4,7 +4,7 @@ import com.google.cloud.bigquery.connector.common.BigQueryPushdownUnsupportedExc
 import com.google.cloud.spark.bigquery.direct.DirectBigQueryRelation
 import com.google.cloud.spark.bigquery.pushdowns.TestConstants.expressionConverter
 import org.apache.spark.sql.catalyst.expressions.aggregate._
-import org.apache.spark.sql.catalyst.expressions.{Abs, Acos, AiqDayDiff, Alias, And, Ascending, Ascii, Asin, Atan, AttributeReference, Base64, BitwiseAnd, BitwiseNot, BitwiseOr, BitwiseXor, CaseWhen, Cast, Coalesce, Concat, Contains, Cos, Cosh, DateAdd, DateSub, DenseRank, Descending, EndsWith, EqualNullSafe, EqualTo, Exp, ExprId, Floor, FormatNumber, FormatString, GreaterThan, GreaterThanOrEqual, Greatest, If, In, InitCap, InSet, IsNaN, IsNotNull, IsNull, Least, Length, LessThan, LessThanOrEqual, Literal, Log10, Logarithm, Lower, Month, Not, Or, PercentRank, Pi, Pow, PromotePrecision, Quarter, Rand, Rank, RegExpExtract, RegExpReplace, Round, RowNumber, ShiftLeft, ShiftRight, Signum, Sin, Sinh, SortOrder, SoundEx, Sqrt, StartsWith, StringInstr, StringLPad, StringRPad, StringTranslate, StringTrim, StringTrimLeft, StringTrimRight, Substring, Tan, Tanh, TruncDate, UnBase64, UnscaledValue, Upper, Year}
+import org.apache.spark.sql.catalyst.expressions.{Abs, Acos, AiqDateToString, AiqDayDiff, Alias, And, Ascending, Ascii, Asin, Atan, AttributeReference, Base64, BitwiseAnd, BitwiseNot, BitwiseOr, BitwiseXor, CaseWhen, Cast, Coalesce, Concat, Contains, Cos, Cosh, DateAdd, DateSub, DenseRank, Descending, EndsWith, EqualNullSafe, EqualTo, Exp, ExprId, Floor, FormatNumber, FormatString, GreaterThan, GreaterThanOrEqual, Greatest, If, In, InitCap, InSet, IsNaN, IsNotNull, IsNull, Least, Length, LessThan, LessThanOrEqual, Literal, Log10, Logarithm, Lower, Month, Not, Or, PercentRank, Pi, Pow, PromotePrecision, Quarter, Rand, Rank, RegExpExtract, RegExpReplace, Round, RowNumber, ShiftLeft, ShiftRight, Signum, Sin, Sinh, SortOrder, SoundEx, Sqrt, StartsWith, StringInstr, StringLPad, StringRPad, StringTranslate, StringTrim, StringTrimLeft, StringTrimRight, Substring, Tan, Tanh, TruncDate, UnBase64, UnscaledValue, Upper, Year}
 import org.apache.spark.sql.types._
 import org.mockito.{Mock, MockitoAnnotations}
 import org.scalatest.BeforeAndAfter
@@ -945,11 +945,19 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
   }
 
   test("convertDateExpressions with AiqDayDiff") {
-    val dayDiff = AiqDayDiff(startMsAttributeReference, Literal(1695945601000L), Literal("UTC"))
-    val bigQuerySQLStatement = expressionConverter.convertDateExpressions(dayDiff, fields)
+    val exp = AiqDayDiff(startMsAttributeReference, Literal(1695945601000L), Literal("UTC"))
+    val bigQuerySQLStatement = expressionConverter.convertDateExpressions(exp, fields)
     assert(bigQuerySQLStatement.exists { s =>
       s.toString == "DATE_DIFF ( DATE ( TIMESTAMP_MILLIS ( 1695945601000 ) , 'UTC' ) , " +
         "DATE ( TIMESTAMP_MILLIS ( STARTMS ) , 'UTC' ) , DAY )"
+    })
+  }
+
+  test("convertDateExpressions with AiqDateToString") {
+    val exp = AiqDateToString(startMsAttributeReference, Literal("yyyy-MM-dd HH:mm"), Literal("America/New_York"))
+    val bigQuerySQLStatement = expressionConverter.convertDateExpressions(exp, fields)
+    assert(bigQuerySQLStatement.exists { s =>
+      s.toString == "CAST ( DATETIME ( TIMESTAMP_MILLIS ( STARTMS ) , 'America/New_York' ) AS STRING FORMAT \"yyyy-MM-dd HH24:mi\""
     })
   }
 


### PR DESCRIPTION
Adding `aiq_date_to_string()` to pushdown. Note I had to do translation logic of `yyyy-mm -> YYYY-MM` similar to how Snowflake [did it here](https://github.com/ActionIQ/spark-snowflake/blob/5bf309bb421294e9b5c250d12b69f0ba24b4836c/src/main/scala/net/snowflake/spark/snowflake/pushdowns/querygeneration/DateStatement.scala#L24-L42) (but not exactly the same). I used the same [test cases copied](https://github.com/ActionIQ/spark-snowflake/blob/5bf309bb421294e9b5c250d12b69f0ba24b4836c/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancementAiqDates.scala#L813-L899) from Snowflake.

When bringing this into Flame, will also add tests there.

### Test Notes
https://github.com/ActionIQ/spark-bigquery-connector?tab=readme-ov-file#unit-tests
https://github.com/ActionIQ/spark-bigquery-connector?tab=readme-ov-file#integration-tests

Some tests fail but also fail without my changes:
```
QueryPushdownIntegrationTestBase.testWindowStatements
```

### Deploy Notes
https://github.com/ActionIQ/spark-bigquery-connector?tab=readme-ov-file#deploy