### PR TITLE
[DP-103] Add aiq_day_start() pushdown

### DIFF
--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -85,7 +85,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq17</revision>
+        <revision>0.30.0-aiq18</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -85,7 +85,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq16</revision>
+        <revision>0.30.0-aiq17</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
@@ -221,6 +221,31 @@ abstract class SparkExpressionConverter {
           blockStatement(
             convertStatement(date, fields) + s", ${format.toString()}"
           )
+
+      /**
+       * --- spark.sql(
+       * ---   "select aiq_day_start(1460080000000, 'America/New_York', 2)"
+       * --- ).as[Long].collect.head == 1460174400000L
+       *
+       * SELECT DATE_PART(
+       *   'EPOCH_MILLISECOND',
+       *   DATE_TRUNC(
+       *     'DAY',
+       *     DATEADD(
+       *       day,
+       *       2,
+       *       CONVERT_TIMEZONE(
+       *         'America/New_York',
+       *         1460080000000::varchar
+       *       )
+       *     )
+       *   )
+       * )
+       * -- 1460174400000
+       */
+      case AiqDayStart(timestamp, timezone, plusDays) =>
+        ???
+
       /**
        * --- spark.sql(
        * ---   """select aiq_day_diff(1693609200000, 1693616400000, 'UTC')"""

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
@@ -4,7 +4,7 @@ import com.google.cloud.bigquery.connector.common.BigQueryPushdownUnsupportedExc
 import com.google.cloud.spark.bigquery.direct.DirectBigQueryRelation
 import com.google.cloud.spark.bigquery.pushdowns.TestConstants.expressionConverter
 import org.apache.spark.sql.catalyst.expressions.aggregate._
-import org.apache.spark.sql.catalyst.expressions.{Abs, Md5, Sha1, Sha2, Acos, AiqDateToString, AiqDayDiff, Alias, And, Ascending, Ascii, Asin, Atan, AttributeReference, Base64, BitwiseAnd, BitwiseNot, BitwiseOr, BitwiseXor, CaseWhen, Cast, Coalesce, Concat, Contains, Cos, Cosh, DateAdd, DateSub, DenseRank, Descending, EndsWith, EqualNullSafe, EqualTo, Exp, ExprId, Floor, FormatNumber, FormatString, GreaterThan, GreaterThanOrEqual, Greatest, If, In, InitCap, InSet, IsNaN, IsNotNull, IsNull, Least, Length, LessThan, LessThanOrEqual, Literal, Log10, Logarithm, Lower, Month, Not, Or, PercentRank, Pi, Pow, PromotePrecision, Quarter, Rand, Rank, RegExpExtract, RegExpReplace, Round, RowNumber, ShiftLeft, ShiftRight, Signum, Sin, Sinh, SortOrder, SoundEx, Sqrt, StartsWith, StringInstr, StringLPad, StringRPad, StringTranslate, StringTrim, StringTrimLeft, StringTrimRight, Substring, Tan, Tanh, TruncDate, UnBase64, UnscaledValue, Upper, Year}
+import org.apache.spark.sql.catalyst.expressions.{Abs, Md5, Sha1, Sha2, Acos, AiqDateToString, AiqDayDiff, AiqDayStart, Alias, And, Ascending, Ascii, Asin, Atan, AttributeReference, Base64, BitwiseAnd, BitwiseNot, BitwiseOr, BitwiseXor, CaseWhen, Cast, Coalesce, Concat, Contains, Cos, Cosh, DateAdd, DateSub, DenseRank, Descending, EndsWith, EqualNullSafe, EqualTo, Exp, ExprId, Floor, FormatNumber, FormatString, GreaterThan, GreaterThanOrEqual, Greatest, If, In, InitCap, InSet, IsNaN, IsNotNull, IsNull, Least, Length, LessThan, LessThanOrEqual, Literal, Log10, Logarithm, Lower, Month, Not, Or, PercentRank, Pi, Pow, PromotePrecision, Quarter, Rand, Rank, RegExpExtract, RegExpReplace, Round, RowNumber, ShiftLeft, ShiftRight, Signum, Sin, Sinh, SortOrder, SoundEx, Sqrt, StartsWith, StringInstr, StringLPad, StringRPad, StringTranslate, StringTrim, StringTrimLeft, StringTrimRight, Substring, Tan, Tanh, TruncDate, UnBase64, UnscaledValue, Upper, Year}
 import org.apache.spark.sql.types._
 import org.mockito.{Mock, MockitoAnnotations}
 import org.scalatest.BeforeAndAfter
@@ -960,6 +960,15 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
     val bigQuerySQLStatement = expressionConverter.convertDateExpressions(yearExpression, fields)
     assert(bigQuerySQLStatement.isDefined)
     assert(bigQuerySQLStatement.get.toString == "DATE_TRUNC ( '2016-07-30' , YEAR )")
+  }
+
+  test("convertDateExpressions with AiqDayStart") {
+    val exp = AiqDayStart(startMsAttributeReference, Literal("America/New_York"), Literal(2))
+    val bigQuerySQLStatement = expressionConverter.convertDateExpressions(exp, fields)
+    assert(bigQuerySQLStatement.get.toString ==
+      "UNIX_MILLIS ( TIMESTAMP ( DATETIME_TRUNC ( DATETIME_ADD ( DATETIME ( TIMESTAMP_MILLIS ( " +
+      "STARTMS ) , 'America/New_York' ) , INTERVAL 2 DAY ) , DAY ) , 'America/New_York' ) )"
+    )
   }
 
   test("convertDateExpressions with AiqDayDiff") {

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
@@ -967,7 +967,7 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
     val bigQuerySQLStatement = expressionConverter.convertDateExpressions(exp, fields)
     assert(bigQuerySQLStatement.get.toString ==
       "UNIX_MILLIS ( TIMESTAMP ( DATETIME_TRUNC ( DATETIME_ADD ( DATETIME ( TIMESTAMP_MILLIS ( " +
-      "STARTMS ) , 'America/New_York' ) , INTERVAL 2 DAY ) , DAY ) , 'America/New_York' ) )"
+      "STARTMS ) , 'America/New_York' ) , INTERVAL 2  DAY ) , DAY ) , 'America/New_York' ) )"
     )
   }
 


### PR DESCRIPTION
Adding `aiq_day_start()`, same test cases as [Snowflake here
](https://github.com/ActionIQ/spark-snowflake/blob/5bf309bb421294e9b5c250d12b69f0ba24b4836c/src/it/scala/net/snowflake/spark/snowflake/PushdownEnhancementAiqDates.scala#L706-L726)

### Test Notes
https://github.com/ActionIQ/spark-bigquery-connector?tab=readme-ov-file#unit-tests
https://github.com/ActionIQ/spark-bigquery-connector?tab=readme-ov-file#integration-tests

### Deploy Notes
https://github.com/ActionIQ/spark-bigquery-connector?tab=readme-ov-file#deploy