### PR TITLE
[DP-104] Pushdown for aiq_string_to_date + fixes for format_number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1293,6 +1293,7 @@ The user/password for Artifactory should come from ~/.m2/settings.xml, which was
 Download / create a JSON file containing real GCP credentials
 ```
 export GOOGLE_APPLICATION_CREDENTIALS=<path to json file>
+export GOOGLE_CLOUD_PROJECT=aiq-dev
 ```
 
 # Version
@@ -1311,14 +1312,7 @@ Run all tests except acceptance test and integration tests
 ```
 
 # Integration Tests
-To run integration test with `aiq-dev` BigQuery instance, download the service account credentials to a local
-file, then run
-```
-export GOOGLE_APPLICATION_CREDENTIALS=<path_to_the_file>
-export GOOGLE_CLOUD_PROJECT=aiq-dev
-```
 
-Run integration tests:
 ```
 # make sure to do this after updating tests - for some reason failsafe:integration-test doesn't compile tests before running
 ./mvnw install -Pintegration -DskipTests

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
@@ -401,7 +401,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(8)).isEqualTo(true); // In
   }
 
-  @Test("TODO: give this more memory")
+  @Ignore("TODO: give this more memory")
   public void testWindowStatements() {
     Dataset<Row> df =
         spark

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
@@ -235,7 +235,8 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
                 "MD5(word)",
                 "SHA1(word)",
                 "SHA2(word, 256)",
-                "CONV(SUBSTRING(CAST(MD5(word) AS STRING), 0, 5), 16, 10)")
+                "CONV(SUBSTRING(CAST(MD5(word) AS STRING), 0, 5), 16, 10)",
+                "word_count % 3")
             .where("word_count = 10 and word = 'glass'");
     List<Row> result = df.collectAsList();
     Row r1 = result.get(0);
@@ -266,6 +267,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(
         r1.getString(25) == "EyoaORzOGBxJCixDUFlyIfrZriB3FNH5oQ9nvLHIKI0="); // SHA2(word, 256)
     assertThat(r1.getString(26) == "153356");
+    assertThat(r1.getLong(27) == 1L);
   }
 
   @Test

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
@@ -48,7 +48,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
         .collect(Collectors.toList());
   }
 
-  @Ignore
+  @Test
   public void testApproxCountDistinct() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt");
     df.createOrReplaceTempView("dt");
@@ -60,7 +60,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assert (results.get(0).getLong(1) == 1);
   }
 
-  @Ignore
+  @Test
   public void testStringFunctionExpressions() {
     Dataset<Row> df =
         spark
@@ -93,7 +93,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
                 "LIKE(word, '%aug%urs%') as like_with_percent",
                 "LIKE(word, 'a_g_rs') as like_with_underscore",
                 "LIKE(word, 'b_g_rs') as like_with_underscore_return_false",
-                "FORMAT_NUMBER(CAST((LENGTH(word) + 10000) AS FLOAT)/6, 3)",
+                "FORMAT_NUMBER(CAST((word_count + 10000) AS FLOAT)/6, 3)",
                 "FORMAT_NUMBER(word_count + 10000, 0)")
             .where("word = 'augurs'");
     List<Row> result = df.collectAsList();
@@ -126,7 +126,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.getString(24).equals("10,001"));
   }
 
-  @Ignore
+  @Test
   public void testDateFunctionExpressions() {
     // This table only has one row and one column which is today's date
     Dataset<Row> df =
@@ -166,7 +166,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(6).toString()).isEqualTo(date.with(firstDayOfYear()).toString()); // TRUNC
   }
 
-  @Ignore
+  @Test
   public void testBasicExpressions() {
     Dataset<Row> df =
         spark
@@ -199,7 +199,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(4)).isEqualTo(false); // 'augurs' <=> 'sonnets'
   }
 
-  @Ignore
+  @Test
   public void testMathematicalFunctionExpressions() {
     Dataset<Row> df =
         spark
@@ -270,7 +270,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.getLong(27) == 1L);
   }
 
-  @Ignore
+  @Test
   public void testMiscellaneousExpressions() {
     Dataset<Row> df =
         spark
@@ -312,7 +312,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(11)).isEqualTo(false); // CHECKOVERFLOW
   }
 
-  @Ignore
+  @Test
   public void testUnionQuery() {
     Dataset<Row> df =
         spark
@@ -341,7 +341,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(unionByNameList.get(0).get(1)).isAnyOf(100L, 150L);
   }
 
-  @Ignore
+  @Test
   public void testBooleanExpressions() {
     Dataset<Row> df =
         spark
@@ -452,7 +452,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(row.get(10)).isEqualTo(3677); // COUNT(word) OVER count_window
   }
 
-  @Ignore
+  @Test
   public void testWindowQueryWithWindowSpec() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -504,7 +504,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r.get(2)).isEqualTo(4);
   }
 
-  @Ignore
+  @Test
   public void testAggregateExpressions() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -547,7 +547,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(11)).isEqualTo(0.5); // VAR_SAMP(num1)
   }
 
-  @Ignore
+  @Test
   public void testInnerJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -610,7 +610,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Ignore
+  @Test
   public void testLeftOuterJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -711,7 +711,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Ignore
+  @Test
   public void testRightOuterJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -814,7 +814,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Ignore
+  @Test
   public void testFullOuterJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -919,7 +919,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Ignore
+  @Test
   public void testCrossJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -962,7 +962,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(df_to_join.crossJoin(df).collectAsList().size()).isEqualTo(6);
   }
 
-  @Ignore
+  @Test
   public void testLeftSemiJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -1025,7 +1025,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Ignore
+  @Test
   public void testLeftAntiJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -1081,7 +1081,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(result.get(0).get(0)).isEqualTo(6);
   }
 
-  @Ignore
+  @Test
   public void testJoinQuery() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -1154,7 +1154,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
    * unix_millis(timestamp("2023-09-01T23:59:59")),
    * unix_millis(timestamp("2023-09-02T00:00:00")),"Asia/Shanghai");
    */
-  @Ignore
+  @Test
   public void testAiqDayDiff() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt");
     df.createOrReplaceTempView("dt");
@@ -1181,7 +1181,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
    * 'America/New_York'), ('2019-09-01 02:50 PM', 'yyyy-MM-dd hh:mm a', 'America/New_York'),
    * ('2019-09-01 PM 02:50', 'yyyy-MM-dd a hh:mm', 'America/New_York')
    */
-  @Ignore
+  @Test
   public void testAiqStringToDate() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt5");
     df.createOrReplaceTempView("dt5");
@@ -1208,12 +1208,6 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
   public void testAiqDateToStringPart1() {
     var df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt3");
     df.createOrReplaceTempView("dt3");
-
-    /*
-    TODO: some test cases missing here
-
-    "yyyy-MM-dd aMa HH:mm:ss" ->
-     */
 
     var formatTestsWithIndex =
         zipWithIndex(
@@ -1257,8 +1251,6 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
             .map(r -> r.getString(1))
             .collect(Collectors.toList());
 
-    System.out.println("AIQDATETOSTRING " + results);
-
     assert (results.equals(
         Arrays.asList(
             "09",
@@ -1300,7 +1292,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
    * 'America/New_York'), (7, 1567363852000, 'yyyy-MM-dd hh:mm:ss', 'America/New_York'), (8,
    * 1567363852000, 'yyyy-MM-dd hh:mm:mm:ss', 'America/New_York')
    */
-  @Ignore
+  @Test
   public void testAiqDateToStringPart2() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt2");
     df.createOrReplaceTempView("dt2");
@@ -1333,7 +1325,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
    * <p>insert into aiq-dev.connector_dev.dt4 values(1460080000000, 'America/New_York', 2) insert
    * into aiq-dev.connector_dev.dt4 values(1460080000000, 'Asia/Tokyo', -1)
    */
-  @Ignore
+  @Test
   public void testAiqDayStart() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt4");
     df.createOrReplaceTempView("dt4");
@@ -1348,7 +1340,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
   }
 
   /** Test for AIQ EXE-2026 */
-  @Ignore
+  @Test
   public void testSourceQuery() {
     spark
         .sqlContext()

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
@@ -48,7 +48,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
         .collect(Collectors.toList());
   }
 
-  @Test
+  @Ignore
   public void testApproxCountDistinct() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt");
     df.createOrReplaceTempView("dt");
@@ -60,7 +60,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assert (results.get(0).getLong(1) == 1);
   }
 
-  @Test
+  @Ignore
   public void testStringFunctionExpressions() {
     Dataset<Row> df =
         spark
@@ -93,7 +93,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
                 "LIKE(word, '%aug%urs%') as like_with_percent",
                 "LIKE(word, 'a_g_rs') as like_with_underscore",
                 "LIKE(word, 'b_g_rs') as like_with_underscore_return_false",
-                "FORMAT_NUMBER(CAST((word_count + 10000) AS FLOAT)/6, 3)",
+                "FORMAT_NUMBER(CAST((LENGTH(word) + 10000) AS FLOAT)/6, 3)",
                 "FORMAT_NUMBER(word_count + 10000, 0)")
             .where("word = 'augurs'");
     List<Row> result = df.collectAsList();
@@ -126,7 +126,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.getString(24).equals("10,001"));
   }
 
-  @Test
+  @Ignore
   public void testDateFunctionExpressions() {
     // This table only has one row and one column which is today's date
     Dataset<Row> df =
@@ -166,7 +166,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(6).toString()).isEqualTo(date.with(firstDayOfYear()).toString()); // TRUNC
   }
 
-  @Test
+  @Ignore
   public void testBasicExpressions() {
     Dataset<Row> df =
         spark
@@ -199,7 +199,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(4)).isEqualTo(false); // 'augurs' <=> 'sonnets'
   }
 
-  @Test
+  @Ignore
   public void testMathematicalFunctionExpressions() {
     Dataset<Row> df =
         spark
@@ -270,7 +270,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.getLong(27) == 1L);
   }
 
-  @Test
+  @Ignore
   public void testMiscellaneousExpressions() {
     Dataset<Row> df =
         spark
@@ -312,7 +312,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(11)).isEqualTo(false); // CHECKOVERFLOW
   }
 
-  @Test
+  @Ignore
   public void testUnionQuery() {
     Dataset<Row> df =
         spark
@@ -341,7 +341,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(unionByNameList.get(0).get(1)).isAnyOf(100L, 150L);
   }
 
-  @Test
+  @Ignore
   public void testBooleanExpressions() {
     Dataset<Row> df =
         spark
@@ -452,7 +452,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(row.get(10)).isEqualTo(3677); // COUNT(word) OVER count_window
   }
 
-  @Test
+  @Ignore
   public void testWindowQueryWithWindowSpec() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -504,7 +504,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r.get(2)).isEqualTo(4);
   }
 
-  @Test
+  @Ignore
   public void testAggregateExpressions() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -547,7 +547,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(11)).isEqualTo(0.5); // VAR_SAMP(num1)
   }
 
-  @Test
+  @Ignore
   public void testInnerJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -610,7 +610,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Test
+  @Ignore
   public void testLeftOuterJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -711,7 +711,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Test
+  @Ignore
   public void testRightOuterJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -814,7 +814,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Test
+  @Ignore
   public void testFullOuterJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -919,7 +919,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Test
+  @Ignore
   public void testCrossJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -962,7 +962,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(df_to_join.crossJoin(df).collectAsList().size()).isEqualTo(6);
   }
 
-  @Test
+  @Ignore
   public void testLeftSemiJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -1025,7 +1025,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     }
   }
 
-  @Test
+  @Ignore
   public void testLeftAntiJoin() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -1081,7 +1081,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(result.get(0).get(0)).isEqualTo(6);
   }
 
-  @Test
+  @Ignore
   public void testJoinQuery() {
     writeTestDataToBigQuery(
         getNumStructDataFrame(TestConstants.numStructDataset),
@@ -1154,7 +1154,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
    * unix_millis(timestamp("2023-09-01T23:59:59")),
    * unix_millis(timestamp("2023-09-02T00:00:00")),"Asia/Shanghai");
    */
-  @Test
+  @Ignore
   public void testAiqDayDiff() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt");
     df.createOrReplaceTempView("dt");
@@ -1181,7 +1181,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
    * 'America/New_York'), ('2019-09-01 02:50 PM', 'yyyy-MM-dd hh:mm a', 'America/New_York'),
    * ('2019-09-01 PM 02:50', 'yyyy-MM-dd a hh:mm', 'America/New_York')
    */
-  @Test
+  @Ignore
   public void testAiqStringToDate() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt5");
     df.createOrReplaceTempView("dt5");
@@ -1251,6 +1251,8 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
             .map(r -> r.getString(1))
             .collect(Collectors.toList());
 
+    System.out.println("AIQDATETOSTRING " + results);
+
     assert (results.equals(
         Arrays.asList(
             "09",
@@ -1292,7 +1294,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
    * 'America/New_York'), (7, 1567363852000, 'yyyy-MM-dd hh:mm:ss', 'America/New_York'), (8,
    * 1567363852000, 'yyyy-MM-dd hh:mm:mm:ss', 'America/New_York')
    */
-  @Test
+  @Ignore
   public void testAiqDateToStringPart2() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt2");
     df.createOrReplaceTempView("dt2");
@@ -1325,7 +1327,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
    * <p>insert into aiq-dev.connector_dev.dt4 values(1460080000000, 'America/New_York', 2) insert
    * into aiq-dev.connector_dev.dt4 values(1460080000000, 'Asia/Tokyo', -1)
    */
-  @Test
+  @Ignore
   public void testAiqDayStart() {
     Dataset<Row> df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt4");
     df.createOrReplaceTempView("dt4");
@@ -1340,7 +1342,7 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
   }
 
   /** Test for AIQ EXE-2026 */
-  @Test
+  @Ignore
   public void testSourceQuery() {
     spark
         .sqlContext()

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
@@ -122,8 +122,8 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     assertThat(r1.get(20)).isEqualTo(true); // LIKE(word, '%aug%urs%')
     assertThat(r1.get(21)).isEqualTo(true); // LIKE(word, 'a_g_rs')
     assertThat(r1.get(22)).isEqualTo(false); // LIKE(word, 'b_g_rs')
-    assertThat(r1.getString(23) == "1,666.833");
-    assertThat(r1.getString(24) == "10,001");
+    assertThat(r1.getString(23).equals("1,666.833"));
+    assertThat(r1.getString(24).equals("10,001"));
   }
 
   @Test

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/QueryPushdownIntegrationTestBase.java
@@ -1209,6 +1209,12 @@ public class QueryPushdownIntegrationTestBase extends SparkBigQueryIntegrationTe
     var df = readTestDataFromBigQuery("connector_dev", "connector_dev.dt3");
     df.createOrReplaceTempView("dt3");
 
+    /*
+    TODO: some test cases missing here
+
+    "yyyy-MM-dd aMa HH:mm:ss" ->
+     */
+
     var formatTestsWithIndex =
         zipWithIndex(
             Arrays.asList(

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -85,7 +85,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq19</revision>
+        <revision>0.30.0-aiq20</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -85,7 +85,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq23</revision>
+        <revision>0.30.0-aiq24</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -85,7 +85,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq21</revision>
+        <revision>0.30.0-aiq22</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -85,7 +85,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq20</revision>
+        <revision>0.30.0-aiq21</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -85,7 +85,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq22</revision>
+        <revision>0.30.0-aiq23</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
@@ -534,6 +534,8 @@ abstract class SparkExpressionConverter {
     })
   }
 
+  private def isIntegralType(dt: DataType): Boolean = dt.isInstanceOf[LongType] || dt.isInstanceOf[IntegerType]
+
   def convertStringExpressions(expression: Expression, fields: Seq[Attribute]): Option[BigQuerySQLStatement] = {
     Option(expression match {
       case _: Ascii | _: Concat | _: Length | _: Lower |
@@ -566,12 +568,12 @@ abstract class SparkExpressionConverter {
        * )
        */
       case FormatNumber(numberExp, decimalPlacesExp)
-          if decimalPlacesExp.foldable && decimalPlacesExp.dataType == IntegerType && decimalPlacesExp.toString == "0" =>
+          if decimalPlacesExp.foldable && isIntegralType(decimalPlacesExp.dataType) && decimalPlacesExp.toString == "0" =>
         val firstPart = FormatString(Literal("%\\\'d"), Cast(numberExp, LongType))
         convertStatement(firstPart, fields)
 
       case FormatNumber(numberExp, decimalPlacesExp)
-          if decimalPlacesExp.foldable && decimalPlacesExp.dataType == IntegerType =>
+          if decimalPlacesExp.foldable && isIntegralType(decimalPlacesExp.dataType) =>
         val firstPart = FormatString(Literal("%\\\'d"), Cast(numberExp, LongType))
         val secondPart = Substring(
           FormatString(Literal("%.4f"), Remainder(Cast(numberExp, FloatType), Literal(1))),

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
@@ -107,7 +107,7 @@ abstract class SparkExpressionConverter {
       // https://cloud.google.com/bigquery/docs/reference/standard-sql/operators
       case Remainder(a, b, _) =>
         ConstantString("MOD") + blockStatement(
-          convertStatement(a, fields) + "," + convertStatement(b, fields)
+          convertStatement(Cast(a, LongType), fields) + "," + convertStatement(Cast(b, LongType), fields)
         )
 
       case b @ BinaryOperator(left, right) =>
@@ -403,11 +403,6 @@ abstract class SparkExpressionConverter {
            _: Sqrt | _: Tan | _: Tanh =>
         ConstantString(expression.prettyName.toUpperCase) + blockStatement(convertStatements(fields, expression.children: _*))
 
-      case Remainder(a, b, _) =>
-        ConstantString("MOD") + blockStatement(
-          convertStatement(a, fields) + "," + convertStatement(b, fields)
-        )
-
       /**
        * Only supporting 16 -> 10 for now
        *
@@ -576,7 +571,7 @@ abstract class SparkExpressionConverter {
           if decimalPlacesExp.foldable && isIntegralType(decimalPlacesExp.dataType) =>
         val firstPart = FormatString(Literal("%\\\'d"), Cast(numberExp, LongType))
         val secondPart = Substring(
-          FormatString(Literal("%.4f"), Remainder(Cast(numberExp, FloatType), Literal(1))),
+          FormatString(Literal("%.4f"), Remainder(numberExp, Literal(1L))),
           Literal(2),
           Literal(decimalPlacesExp.toString.toInt + 1)
         )

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
@@ -571,7 +571,7 @@ abstract class SparkExpressionConverter {
           if decimalPlacesExp.foldable && isIntegralType(decimalPlacesExp.dataType) =>
         val firstPart = FormatString(Literal("%\\\'d"), Cast(numberExp, LongType))
         val secondPart = Substring(
-          FormatString(Literal("%.4f"), Remainder(numberExp, Literal(1L))),
+          FormatString(Literal("%.4f"), Cast(Remainder(numberExp, Literal(1L)), FloatType)),
           Literal(2),
           Literal(decimalPlacesExp.toString.toInt + 1)
         )

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
@@ -103,7 +103,7 @@ abstract class SparkExpressionConverter {
             ConstantString("COALESCE") + blockStatement( ConstantString("CAST") + blockStatement(convertStatement(right, fields) + ConstantString("AS STRING") ) + "," + ConstantString("\"\"") )
         )
 
-      // Bigquery does not support '%' => MOD
+      // Bigquery does not support '%'
       // https://cloud.google.com/bigquery/docs/reference/standard-sql/operators
       case Remainder(a, b, _) =>
         ConstantString("MOD") + blockStatement(

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
@@ -344,14 +344,8 @@ abstract class SparkExpressionConverter {
       "Z" -> "%Z"     // UTC offset
     )
 
-    def replaceFormat(str: String, map: Map[String, String]): String = {
-      map.foldLeft(str) { case (acc, (key, value)) =>
-        acc.replace(key, value)
-      }
-    }
-
     // Replace ISO 8601 specifiers with BigQuery specifiers
-    val transformed = formatMap.foldLeft(isoFormat) { case (last, (nextFmtKey, nextFmtVal)) =>
+    val transformed = formatMap.foldLeft(format) { case (last, (nextFmtKey, nextFmtVal)) =>
       last.replace(nextFmtKey, nextFmtVal)
     }
 

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
@@ -338,11 +338,9 @@ abstract class SparkExpressionConverter {
     // be careful with the order here, you dont want MMM -> Month -> MMonth
     format
       // Full year
-      .replaceAll("y{4,8}", "%Y")
-      .replaceAll("Y{4,8}", "%Y")
+      .replaceAll("[yY]{4,8}", "%Y")
       // Two-digit year
-      .replaceAll("y{2}", "%y")
-      .replaceAll("Y{2}", "%y")
+      .replaceAll("[yY]{2}", "%y")
       // Full month name
       .replaceAll("M{4,8}", "%B")
       // Abbreviated month name
@@ -365,8 +363,7 @@ abstract class SparkExpressionConverter {
       // Abbreviated day of week
       .replaceAll("E{1,3}", "%a")
       // Two digits for day
-      .replaceAll("dd", "%d")
-      .replaceAll("DD", "%d")
+      .replaceAll("[dD]{2}", "%d")
   }
 
   /**
@@ -381,18 +378,17 @@ abstract class SparkExpressionConverter {
   private def isoDateFmtToBigQueryFormat(format: String): String = {
     // be careful with the order here, you dont want MMM -> Month -> MMonth
     format
-      // Two-digit year
-      .replaceAll("y{2}", "YY")
-      .replaceAll("Y{2}", "YY")
       // Full year
-      .replaceAll("y{4,8}", "YYYY")
-      .replaceAll("Y{4,8}", "YYYY")
-      // Two-digit month
-      .replaceAll("M{1,2}", "MM")
+      .replaceAll("[yY]{4,8}", "YYYY")
+      // Two-digit year
+      .replaceAll("[yY]{2}", "YY")
       // Full month name
       .replaceAll("M{4,8}", "Month")
       // Abbreviated month name
       .replaceAll("M{3}", "Mon")
+      // Two-digit month
+      .replaceAll("(?<=[^M])MM(?=[^M])", "MM")
+      .replaceAll("(?<=[^M])M(?=[^Mo])", "MM")
       // Two digits for hour (00 through 23)
       .replaceAll("HH", "HH24")
       // Two digits for hour (01 through 12)
@@ -405,12 +401,11 @@ abstract class SparkExpressionConverter {
       .replaceAll("p", "AM")
       .replaceAll("a", "AM")
       // Two digits for day
-      .replaceAll("dd", "DD")
-      .replaceAll("DD", "DD")
-      // Abbreviated day of week
-      .replaceAll("E{1,3}", "Dy")
+      .replaceAll("[dD]{2}", "DD")
       // Full day of week
       .replaceAll("E{4,8}", "Day")
+      // Abbreviated day of week
+      .replaceAll("E{1,3}", "Dy")
   }
 
   def convertMathematicalExpressions(expression: Expression, fields: Seq[Attribute]): Option[BigQuerySQLStatement] = {

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
@@ -560,12 +560,12 @@ abstract class SparkExpressionConverter {
        */
       case FormatNumber(numberExp, decimalPlacesExp)
           if decimalPlacesExp.foldable && decimalPlacesExp.dataType == IntegerType && decimalPlacesExp.toString == "0" =>
-        val firstPart = FormatString(Literal("%'d"), Cast(Cast(numberExp, FloatType), LongType))
+        val firstPart = FormatString(Literal("%\\'d"), Cast(Cast(numberExp, FloatType), LongType))
         convertStatement(firstPart, fields)
 
       case FormatNumber(numberExp, decimalPlacesExp)
           if decimalPlacesExp.foldable && decimalPlacesExp.dataType == IntegerType =>
-        val firstPart = FormatString(Literal("%\'d"), Cast(Cast(numberExp, FloatType), LongType))
+        val firstPart = FormatString(Literal("%\\'d"), Cast(Cast(numberExp, FloatType), LongType))
         val secondPart = Substring(
           FormatString(Literal("%.4f"), Remainder(Cast(numberExp, FloatType), Literal(1))),
           Literal(2),

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
@@ -329,7 +329,7 @@ abstract class SparkExpressionConverter {
    */
   private def isoDateFmtToBigQueryParse(format: String): String = {
     // be careful with the order here, you dont want mmM -> %MM -> %%m
-    val formatMap = Map(
+    val formatMap = Seq(
       "YYYY" -> "%Y", // Four-digit year
       "yyyy" -> "%Y", // Four-digit year (alternative)
       "YY" -> "%y",   // Two-digit year
@@ -560,12 +560,12 @@ abstract class SparkExpressionConverter {
        */
       case FormatNumber(numberExp, decimalPlacesExp)
           if decimalPlacesExp.foldable && decimalPlacesExp.dataType == IntegerType && decimalPlacesExp.toString == "0" =>
-        val firstPart = FormatString(Literal("%\\'d"), Cast(Cast(numberExp, FloatType), LongType))
+        val firstPart = FormatString(Literal("%\\\'d"), Cast(Cast(numberExp, FloatType), LongType))
         convertStatement(firstPart, fields)
 
       case FormatNumber(numberExp, decimalPlacesExp)
           if decimalPlacesExp.foldable && decimalPlacesExp.dataType == IntegerType =>
-        val firstPart = FormatString(Literal("%\\'d"), Cast(Cast(numberExp, FloatType), LongType))
+        val firstPart = FormatString(Literal("%\\\'d"), Cast(Cast(numberExp, FloatType), LongType))
         val secondPart = Substring(
           FormatString(Literal("%.4f"), Remainder(Cast(numberExp, FloatType), Literal(1))),
           Literal(2),

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
@@ -501,7 +501,7 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
   test("convertStringExpressions with FormatNumber") {
     val formatNumberExpression = FormatNumber.apply(Literal(1245.3456), Literal(2))
     val bigQuerySQLStatement = expressionConverter.convertStringExpressions(formatNumberExpression, fields)
-    val firstPart = "FORMAT ( '%'d' , CAST ( CAST ( 1245.3456 AS FLOAT64 ) AS INT64 ) )"
+    val firstPart = "FORMAT ( '%\\'d' , CAST ( CAST ( 1245.3456 AS FLOAT64 ) AS INT64 ) )"
     val secondPart = "SUBSTRING ( FORMAT ( '%.4f' , ( CAST ( 1245.3456 AS FLOAT64 ) % 1 ) ) , 2 , 3 )"
     assert(bigQuerySQLStatement.get.toString == s"CONCAT ( $firstPart , $secondPart )")
   }
@@ -510,7 +510,7 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
     val formatNumberExpression = FormatNumber.apply(Literal(1234.3456), Literal(0))
     val bigQuerySQLStatement = expressionConverter.convertStringExpressions(formatNumberExpression, fields)
     assert(bigQuerySQLStatement.isDefined)
-    assert(bigQuerySQLStatement.get.toString == "FORMAT ( '%\'d' , CAST ( CAST ( 1234.3456 AS FLOAT64 ) AS INT64 ) )")
+    assert(bigQuerySQLStatement.get.toString == "FORMAT ( '%\\'d' , CAST ( CAST ( 1234.3456 AS FLOAT64 ) AS INT64 ) )")
   }
 
   test("convertMathematicalExpressions with conv") {

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
@@ -1017,7 +1017,7 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
     val exp = AiqDateToString(startMsAttributeReference, Literal("yyyy-MM-dd HH:mm"), Literal("America/New_York"))
     val bigQuerySQLStatement = expressionConverter.convertDateExpressions(exp, fields)
     assert(
-      bigQuerySQLStatement.get.toString == "CAST ( DATETIME ( TIMESTAMP_MILLIS ( STARTMS ) , 'America/New_York' ) AS STRING FORMAT \"yyyy-MM-dd HH24:MI\" )"
+      bigQuerySQLStatement.get.toString == "CAST ( DATETIME ( TIMESTAMP_MILLIS ( STARTMS ) , 'America/New_York' ) AS STRING FORMAT \"YYYY-MM-DD HH24:MI\" )"
     )
   }
 

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
@@ -501,8 +501,8 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
   test("convertStringExpressions with FormatNumber") {
     val formatNumberExpression = FormatNumber.apply(Literal(1245.3456), Literal(2))
     val bigQuerySQLStatement = expressionConverter.convertStringExpressions(formatNumberExpression, fields)
-    val firstPart = "FORMAT ( '%\\'d' , CAST ( CAST ( 1245.3456 AS FLOAT64 ) AS INT64 ) )"
-    val secondPart = "SUBSTRING ( FORMAT ( '%.4f' , ( CAST ( 1245.3456 AS FLOAT64 ) % 1 ) ) , 2 , 3 )"
+    val firstPart = "FORMAT ( '%\\'d' , CAST ( 1245.3456 AS INT64 ) )"
+    val secondPart = "SUBSTRING ( FORMAT ( '%.4f' , MOD ( CAST ( 1245.3456 AS FLOAT64 ) , 1 ) ) , 2 , 3 )"
     assert(bigQuerySQLStatement.get.toString == s"CONCAT ( $firstPart , $secondPart )")
   }
 
@@ -510,7 +510,7 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
     val formatNumberExpression = FormatNumber.apply(Literal(1234.3456), Literal(0))
     val bigQuerySQLStatement = expressionConverter.convertStringExpressions(formatNumberExpression, fields)
     assert(bigQuerySQLStatement.isDefined)
-    assert(bigQuerySQLStatement.get.toString == "FORMAT ( '%\\'d' , CAST ( CAST ( 1234.3456 AS FLOAT64 ) AS INT64 ) )")
+    assert(bigQuerySQLStatement.get.toString == "FORMAT ( '%\\'d' , CAST ( 1234.3456 AS INT64 ) )")
   }
 
   test("convertMathematicalExpressions with conv") {

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
@@ -137,7 +137,7 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
     val binaryOperatorExpression = Remainder(schoolIdAttributeReference, Literal.apply(75L, LongType))
     val bigQuerySQLStatement = expressionConverter.convertBasicExpressions(binaryOperatorExpression, fields)
     assert(bigQuerySQLStatement.isDefined)
-    assert(bigQuerySQLStatement.get.toString == "MOD ( SUBQUERY_2.SCHOOLID , 75 )")
+    assert(bigQuerySQLStatement.get.toString == "MOD ( CAST ( SUBQUERY_2.SCHOOLID AS INT64 ) , CAST ( 75 AS INT64 ) )")
   }
 
   test("convertBasicExpressions with BinaryOperator (GreaterThanOrEqual)") {

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
@@ -137,7 +137,7 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
     val binaryOperatorExpression = Remainder(schoolIdAttributeReference, Literal.apply(75L, LongType))
     val bigQuerySQLStatement = expressionConverter.convertBasicExpressions(binaryOperatorExpression, fields)
     assert(bigQuerySQLStatement.isDefined)
-    assert(bigQuerySQLStatement.get.toString == "MOD ( CAST ( SUBQUERY_2.SCHOOLID AS INT64 ) , CAST ( 75 AS INT64 ) )")
+    assert(bigQuerySQLStatement.get.toString == "MOD ( SUBQUERY_2.SCHOOLID , 75 )")
   }
 
   test("convertBasicExpressions with BinaryOperator (GreaterThanOrEqual)") {
@@ -509,7 +509,7 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
     val formatNumberExpression = FormatNumber.apply(Literal(1245.3456), Literal(2))
     val bigQuerySQLStatement = expressionConverter.convertStringExpressions(formatNumberExpression, fields)
     val firstPart = "FORMAT ( '%\\'d' , CAST ( 1245.3456 AS INT64 ) )"
-    val secondPart = "SUBSTRING ( FORMAT ( '%.4f' , CAST ( MOD ( CAST ( 1245.3456 AS INT64 ) , CAST ( 1 AS INT64 ) ) AS FLOAT64 ) ) , 2 , 3 )"
+    val secondPart = "SUBSTRING ( FORMAT ( '%.4f' , ( 1245.3456 - FLOOR ( 1245.3456 ) ) ) , 2 , 3 )"
     assert(bigQuerySQLStatement.get.toString == s"CONCAT ( $firstPart , $secondPart )")
   }
 

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
@@ -4,7 +4,7 @@ import com.google.cloud.bigquery.connector.common.BigQueryPushdownUnsupportedExc
 import com.google.cloud.spark.bigquery.direct.DirectBigQueryRelation
 import com.google.cloud.spark.bigquery.pushdowns.TestConstants.expressionConverter
 import org.apache.spark.sql.catalyst.expressions.aggregate._
-import org.apache.spark.sql.catalyst.expressions.{Abs, Conv, Md5, Sha1, Sha2, Acos, AiqDateToString, AiqDayDiff, AiqDayStart, Alias, And, Ascending, Ascii, Asin, Atan, AttributeReference, Base64, BitwiseAnd, BitwiseNot, BitwiseOr, BitwiseXor, CaseWhen, Cast, Coalesce, Concat, Contains, Cos, Cosh, DateAdd, DateSub, DenseRank, Descending, EndsWith, EqualNullSafe, EqualTo, Exp, ExprId, Floor, FormatNumber, FormatString, GreaterThan, GreaterThanOrEqual, Greatest, If, In, InitCap, InSet, IsNaN, IsNotNull, IsNull, Least, Length, LessThan, LessThanOrEqual, Literal, Log10, Logarithm, Lower, Month, Not, Or, PercentRank, Pi, Pow, PromotePrecision, Quarter, Rand, Rank, RegExpExtract, RegExpReplace, Round, RowNumber, ShiftLeft, ShiftRight, Signum, Sin, Sinh, SortOrder, SoundEx, Sqrt, StartsWith, StringInstr, StringLPad, StringRPad, StringTranslate, StringTrim, StringTrimLeft, StringTrimRight, Substring, Tan, Tanh, TruncDate, UnBase64, UnscaledValue, Upper, Year}
+import org.apache.spark.sql.catalyst.expressions.{Abs, Conv, Md5, Sha1, Sha2, Acos, AiqDateToString, AiqDayDiff, AiqDayStart, AiqStringToDate, Alias, And, Ascending, Ascii, Asin, Atan, AttributeReference, Base64, BitwiseAnd, BitwiseNot, BitwiseOr, BitwiseXor, CaseWhen, Cast, Coalesce, Concat, Contains, Cos, Cosh, DateAdd, DateSub, DenseRank, Descending, EndsWith, EqualNullSafe, EqualTo, Exp, ExprId, Floor, FormatNumber, FormatString, GreaterThan, GreaterThanOrEqual, Greatest, If, In, InitCap, InSet, IsNaN, IsNotNull, IsNull, Least, Length, LessThan, LessThanOrEqual, Literal, Log10, Logarithm, Lower, Month, Not, Or, PercentRank, Pi, Pow, PromotePrecision, Quarter, Rand, Rank, RegExpExtract, RegExpReplace, Round, RowNumber, ShiftLeft, ShiftRight, Signum, Sin, Sinh, SortOrder, SoundEx, Sqrt, StartsWith, StringInstr, StringLPad, StringRPad, StringTranslate, StringTrim, StringTrimLeft, StringTrimRight, Substring, Tan, Tanh, TruncDate, UnBase64, UnscaledValue, Upper, Year}
 import org.apache.spark.sql.types._
 import org.mockito.{Mock, MockitoAnnotations}
 import org.scalatest.BeforeAndAfter
@@ -991,6 +991,18 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
     val bigQuerySQLStatement = expressionConverter.convertDateExpressions(exp, fields)
     assert(bigQuerySQLStatement.get.toString == "DATE_DIFF ( DATE ( TIMESTAMP_MILLIS ( 1695945601000 ) , 'UTC' ) , " +
         "DATE ( TIMESTAMP_MILLIS ( STARTMS ) , 'UTC' ) , DAY )"
+    )
+  }
+
+  test("convertDateExpressions with AiqStringToDate") {
+    val exp = AiqStringToDate(
+      schoolNameAttributeReference,
+      Literal("yyyy-MM-dd HH:mm:ss"),
+      Literal("America/New_York")
+    )
+    val bigQuerySQLStatement = expressionConverter.convertDateExpressions(exp, fields)
+    assert(bigQuerySQLStatement.get.toString ==
+      "UNIX_MILLIS ( TIMESTAMP ( PARSE_DATETIME ( '%Y-%m-%d %H:%M:%S' , SCHOOLNAME ) , 'America/New_York' ) )"
     )
   }
 

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
@@ -509,7 +509,7 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
     val formatNumberExpression = FormatNumber.apply(Literal(1245.3456), Literal(2))
     val bigQuerySQLStatement = expressionConverter.convertStringExpressions(formatNumberExpression, fields)
     val firstPart = "FORMAT ( '%\\'d' , CAST ( 1245.3456 AS INT64 ) )"
-    val secondPart = "SUBSTRING ( FORMAT ( '%.4f' , MOD ( CAST ( 1245.3456 AS INT64 ) , CAST ( 1 AS INT64 ) ) ) , 2 , 3 )"
+    val secondPart = "SUBSTRING ( FORMAT ( '%.4f' , CAST ( MOD ( CAST ( 1245.3456 AS INT64 ) , CAST ( 1 AS INT64 ) ) AS FLOAT64 ) ) , 2 , 3 )"
     assert(bigQuerySQLStatement.get.toString == s"CONCAT ( $firstPart , $secondPart )")
   }
 


### PR DESCRIPTION
Adding support for `aiq_string_to_date`. Again I had write a little helper function to translate from ISO format to bigquery [parse format](https://cloud.google.com/bigquery/docs/reference/standard-sql/format-elements#format_date_time_as_string).

Also fixing `format_number`, the `mod => %` gets translated incorrectly. EDIT: actually, I ended up using `floor` to implement `format_number`...but also fixed `mod`

### Test Notes
https://github.com/ActionIQ/spark-bigquery-connector?tab=readme-ov-file#unit-tests
https://github.com/ActionIQ/spark-bigquery-connector?tab=readme-ov-file#integration-tests

### Deploy Notes
https://github.com/ActionIQ/spark-bigquery-connector?tab=readme-ov-file#deploy