### PR TITLE
[DP-105] Add tableExpirationMs option to bigquery

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -624,8 +624,8 @@ The API Supports a number of options to configure the read
    <tr valign="top">
     <td><code>tableExpirationMs</code>
      </td>
-     <td>Number of milliseconds to expire the entire table
-        <br/>(Optional. Defaults to not expire).
+     <td>Number of milliseconds to expire the entire table. Will only apply on initial table creation
+        <br/>(Optional. Default to never expire).
      </td>
      <td>Write</td>
    </tr>

--- a/README-template.md
+++ b/README-template.md
@@ -622,6 +622,14 @@ The API Supports a number of options to configure the read
      <td>Write</td>
    </tr>
    <tr valign="top">
+    <td><code>tableExpirationMs</code>
+     </td>
+     <td>Number of milliseconds to expire the entire table
+        <br/>(Optional. Defaults to not expire).
+     </td>
+     <td>Write</td>
+   </tr>
+   <tr valign="top">
        <td><code>partitionType</code>
         </td>
         <td>Supported types are: <code>HOUR, DAY, MONTH, YEAR</code>

--- a/README.md
+++ b/README.md
@@ -1294,6 +1294,7 @@ Download / create a JSON file containing real GCP credentials
 ```
 export GOOGLE_APPLICATION_CREDENTIALS=<path to json file>
 export GOOGLE_CLOUD_PROJECT=aiq-dev
+export TEMPORARY_GCS_BUCKET=foo  # not used unless running indirect tests
 ```
 
 # Version
@@ -1317,12 +1318,10 @@ Run all tests except acceptance test and integration tests
 # make sure to do this after updating tests - for some reason failsafe:integration-test doesn't compile tests before running
 ./mvnw install -Pintegration -DskipTests
 
-# Test pushdown statements
 ./mvnw failsafe:integration-test -fn \
   -Dfailsafe.failIfNoSpecifiedTests=false \
   -Dit.test=com.google.cloud.spark.bigquery.integration.Spark33QueryPushdownIntegrationTest
 
-# Test read
 ./mvnw failsafe:integration-test -fn \
   -Dfailsafe.failIfNoSpecifiedTests=false \
   -Dit.test=com.google.cloud.spark.bigquery.integration.Spark33ReadFromQueryIntegrationTest
@@ -1330,6 +1329,10 @@ Run all tests except acceptance test and integration tests
 ./mvnw failsafe:integration-test -fn \
   -Dfailsafe.failIfNoSpecifiedTests=false \
   -Dit.test=com.google.cloud.spark.bigquery.integration.Spark33ReadIntegrationTest
+
+./mvnw failsafe:integration-test -fn \
+  -Dfailsafe.failIfNoSpecifiedTests=false \
+  -Dit.test=com.google.cloud.spark.bigquery.integration.Spark33DirectWriteIntegrationTest
 ```
 
 If tests failed, there might be some residual testing datasets named with `spark_bigquery_<ts>_<number>`

--- a/README.md
+++ b/README.md
@@ -1294,7 +1294,7 @@ Download / create a JSON file containing real GCP credentials
 ```
 export GOOGLE_APPLICATION_CREDENTIALS=<path to json file>
 export GOOGLE_CLOUD_PROJECT=aiq-dev
-export TEMPORARY_GCS_BUCKET=foo  # not used unless running indirect tests
+export TEMPORARY_GCS_BUCKET=foo  # needed for tests
 ```
 
 # Version

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -626,8 +626,8 @@ public class BigQueryClient {
       TableId tableId, Schema bigQuerySchema, OptionalLong expirationMs) {
     if (!tableExists(tableId)) {
       createTable(tableId, bigQuerySchema, expirationMs);
-    } else {
-      // TODO: set the correct expiration on the table
+    } else if (expirationMs.isPresent()) {
+      log.warn(String.format("Table %s already exists, not applying expiration status", tableId));
     }
   }
 

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -140,9 +140,15 @@ public class BigQueryClient {
    * @param schema The Schema of the table to be created.
    * @return The {@code Table} object representing the table that was created.
    */
-  public TableInfo createTable(TableId tableId, Schema schema) {
-    TableInfo tableInfo = TableInfo.newBuilder(tableId, StandardTableDefinition.of(schema)).build();
-    return bigQuery.create(tableInfo);
+  public TableInfo createTable(TableId tableId, Schema schema, OptionalLong expirationMs) {
+    var baseBuilder = TableInfo.newBuilder(tableId, StandardTableDefinition.of(schema));
+    if (expirationMs.isPresent()) {
+      return bigQuery.create(
+              baseBuilder.setExpirationTime(expirationMs.getAsLong()
+      ).build());
+    } else {
+      return bigQuery.create(baseBuilder.build());
+    }
   }
 
   /**
@@ -617,9 +623,11 @@ public class BigQueryClient {
   }
 
   /** Creates the table with the given schema, only if it does not exist yet. */
-  public void createTableIfNeeded(TableId tableId, Schema bigQuerySchema) {
+  public void createTableIfNeeded(TableId tableId, Schema bigQuerySchema, OptionalLong expirationMs) {
     if (!tableExists(tableId)) {
-      createTable(tableId, bigQuerySchema);
+      createTable(tableId, bigQuerySchema, expirationMs);
+    } else {
+      // TODO: set the correct expiration on the table
     }
   }
 

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -143,9 +143,8 @@ public class BigQueryClient {
   public TableInfo createTable(TableId tableId, Schema schema, OptionalLong expirationMs) {
     var baseBuilder = TableInfo.newBuilder(tableId, StandardTableDefinition.of(schema));
     if (expirationMs.isPresent()) {
-      return bigQuery.create(
-              baseBuilder.setExpirationTime(expirationMs.getAsLong()
-      ).build());
+      var expirationTime = System.currentTimeMillis() + expirationMs.getAsLong();
+      return bigQuery.create(baseBuilder.setExpirationTime(expirationTime).build());
     } else {
       return bigQuery.create(baseBuilder.build());
     }
@@ -623,7 +622,8 @@ public class BigQueryClient {
   }
 
   /** Creates the table with the given schema, only if it does not exist yet. */
-  public void createTableIfNeeded(TableId tableId, Schema bigQuerySchema, OptionalLong expirationMs) {
+  public void createTableIfNeeded(
+      TableId tableId, Schema bigQuerySchema, OptionalLong expirationMs) {
     if (!tableExists(tableId)) {
       createTable(tableId, bigQuerySchema, expirationMs);
     } else {

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -397,7 +397,7 @@ public class SparkBigQueryConfig
     config.partitionExpirationMs =
         getOption(options, "partitionExpirationMs").transform(Long::valueOf).orNull();
     config.tableExpirationMs =
-            getOption(options, "tableExpirationMs").transform(Long::valueOf).orNull();
+        getOption(options, "tableExpirationMs").transform(Long::valueOf).orNull();
     config.partitionRequireFilter =
         getOption(options, "partitionRequireFilter").transform(Boolean::valueOf);
     config.clusteredFields = getOption(options, "clusteredFields").transform(s -> s.split(","));
@@ -744,9 +744,7 @@ public class SparkBigQueryConfig
   }
 
   public OptionalLong getTableExpirationMs() {
-    return tableExpirationMs == null
-            ? OptionalLong.empty()
-            : OptionalLong.of(tableExpirationMs);
+    return tableExpirationMs == null ? OptionalLong.empty() : OptionalLong.of(tableExpirationMs);
   }
 
   public Optional<Boolean> getPartitionRequireFilter() {

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -162,6 +162,7 @@ public class SparkBigQueryConfig
   com.google.common.base.Optional<String> materializationDataset = empty();
   com.google.common.base.Optional<String> partitionField = empty();
   Long partitionExpirationMs = null;
+  Long tableExpirationMs = null;
   com.google.common.base.Optional<Boolean> partitionRequireFilter = empty();
   com.google.common.base.Optional<TimePartitioning.Type> partitionType = empty();
   com.google.common.base.Optional<String[]> clusteredFields = empty();
@@ -395,6 +396,8 @@ public class SparkBigQueryConfig
     config.partitionField = getOption(options, "partitionField");
     config.partitionExpirationMs =
         getOption(options, "partitionExpirationMs").transform(Long::valueOf).orNull();
+    config.tableExpirationMs =
+            getOption(options, "tableExpirationMs").transform(Long::valueOf).orNull();
     config.partitionRequireFilter =
         getOption(options, "partitionRequireFilter").transform(Boolean::valueOf);
     config.clusteredFields = getOption(options, "clusteredFields").transform(s -> s.split(","));
@@ -738,6 +741,12 @@ public class SparkBigQueryConfig
     return partitionExpirationMs == null
         ? OptionalLong.empty()
         : OptionalLong.of(partitionExpirationMs);
+  }
+
+  public OptionalLong getTableExpirationMs() {
+    return tableExpirationMs == null
+            ? OptionalLong.empty()
+            : OptionalLong.of(tableExpirationMs);
   }
 
   public Optional<Boolean> getPartitionRequireFilter() {

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/BigQueryDataSourceWriterInsertableRelation.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/BigQueryDataSourceWriterInsertableRelation.java
@@ -72,7 +72,7 @@ public class BigQueryDataSourceWriterInsertableRelation extends BigQueryInsertab
         Schema bigQuerySchema =
             SchemaConverters.from(SchemaConvertersConfiguration.from(config))
                 .toBigQuerySchema(data.schema());
-        bigQueryClient.createTableIfNeeded(getTableId(), bigQuerySchema);
+        bigQueryClient.createTableIfNeeded(getTableId(), bigQuerySchema, config.getTableExpirationMs());
       } else {
         // Write the data into separate WriteStream (one oer partition, return the
         // WriterCommitMessageContext containing the stream name.

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/BigQueryDataSourceWriterInsertableRelation.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/BigQueryDataSourceWriterInsertableRelation.java
@@ -72,7 +72,8 @@ public class BigQueryDataSourceWriterInsertableRelation extends BigQueryInsertab
         Schema bigQuerySchema =
             SchemaConverters.from(SchemaConvertersConfiguration.from(config))
                 .toBigQuerySchema(data.schema());
-        bigQueryClient.createTableIfNeeded(getTableId(), bigQuerySchema, config.getTableExpirationMs());
+        bigQueryClient.createTableIfNeeded(
+            getTableId(), bigQuerySchema, config.getTableExpirationMs());
       } else {
         // Write the data into separate WriteStream (one oer partition, return the
         // WriterCommitMessageContext containing the stream name.

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDataSourceWriterModule.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDataSourceWriterModule.java
@@ -72,7 +72,8 @@ public class BigQueryDataSourceWriterModule implements Module {
         com.google.common.base.Optional.fromJavaUtil(tableConfig.getTraceId()),
         tableConfig.getEnableModeCheckForSchemaFields(),
         tableConfig.getBigQueryTableLabels(),
-        SchemaConvertersConfiguration.from(tableConfig)); // needs to be serializable
+        SchemaConvertersConfiguration.from(tableConfig), // needs to be serializable
+        tableConfig.getTableExpirationMs());
   }
 
   @Singleton

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContextTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContextTest.java
@@ -31,6 +31,7 @@ import com.google.cloud.spark.bigquery.SchemaConvertersConfiguration;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import java.time.ZoneId;
+import java.util.OptionalLong;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -130,7 +131,7 @@ public class BigQueryDirectDataSourceWriterContextTest {
   @Test
   public void testDeleteOnAbort_newTable() {
     when(bigQueryClient.tableExists(destinationTableId)).thenReturn(false);
-    when(bigQueryClient.createTable(any(), any())).thenReturn(destinationTable);
+    when(bigQueryClient.createTable(any(), any(), any())).thenReturn(destinationTable);
     when(bigQueryClient.createTablePathForBigQueryStorage(any())).thenReturn("");
     BigQueryDirectDataSourceWriterContext ctx =
         createBigQueryDirectDataSourceWriterContext(SaveMode.Append);
@@ -151,6 +152,7 @@ public class BigQueryDirectDataSourceWriterContextTest {
         Optional.absent(),
         true,
         ImmutableMap.<String, String>builder().build(),
-        SchemaConvertersConfiguration.of(ZoneId.of("UTC")));
+        SchemaConvertersConfiguration.of(ZoneId.of("UTC")),
+        OptionalLong.empty());
   }
 }

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -85,7 +85,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq24</revision>
+        <revision>0.30.0-aiq25</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>


### PR DESCRIPTION
Adding option `tableExpirationMs` to expire a table. The internal tables created by the connector already do expiration, but now its a public option.

### Test Notes
https://github.com/ActionIQ/spark-bigquery-connector?tab=readme-ov-file#unit-tests
https://github.com/ActionIQ/spark-bigquery-connector?tab=readme-ov-file#integration-tests

Added integration test

### Deploy Notes
https://github.com/ActionIQ/spark-bigquery-connector?tab=readme-ov-file#deploy