### PR TITLE
[DP-1280] BigQuery write fails with MessageSize is too large

### DIFF
--- a/README.md
+++ b/README.md
@@ -1343,5 +1343,5 @@ TODO figure out acceptance test
 # Deploy
 To deploy to AIQ artifactory https://actioniq.jfrog.io/artifactory/aiq-sbt-local
 ```
-./mvnw deploy
+./mvnw deploy -DskipTests
 ```

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryDirectDataWriterHelper.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryDirectDataWriterHelper.java
@@ -154,7 +154,8 @@ public class BigQueryDirectDataWriterHelper {
    * @throws IOException If sendAppendRowsRequest fails.
    */
   public void addRow(ByteString message) throws IOException {
-    int messageSize = message.size();
+    // https://github.com/GoogleCloudDataproc/spark-bigquery-connector/issues/1116
+    int messageSize = message.size() + 2;
 
     if (appendRequestSizeBytes + messageSize > MAX_APPEND_ROWS_REQUEST_SIZE) {
       // If a single row exceeds the maximum size for an append request, this is a nonrecoverable

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -85,7 +85,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.30.0-aiq26</revision>
+        <revision>0.30.0-aiq27</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>11.0.0</arrow.version>


### PR DESCRIPTION
Backport of https://github.com/GoogleCloudDataproc/spark-bigquery-connector/issues/1116 fix https://github.com/GoogleCloudDataproc/spark-bigquery-connector/pull/1159

### Test Notes
https://github.com/ActionIQ/spark-bigquery-connector?tab=readme-ov-file#unit-tests and also ran the spark shell in the ticket which repros the error

### Deploy Notes
https://github.com/ActionIQ/spark-bigquery-connector?tab=readme-ov-file#deploy